### PR TITLE
adaptations to new slurm grid@jlu

### DIFF
--- a/ggmap/analyses.py
+++ b/ggmap/analyses.py
@@ -4219,7 +4219,7 @@ def _executor(jobname, cache_arguments, pre_execute, commands, post_execute,
         # a potential working directory needs to have the matching job name
         if _dir.startswith('ana_%s_' % results['jobname']):
             # for shared computers, make sure you have permission to read dir contents
-            if not os.access('ana_%s_' % results['jobname'], os.R_OK):
+            if not os.access(os.path.join(dir_tmp, _dir), os.R_OK):
                 continue
             potwd = os.path.join(dir_tmp, _dir)
             # and a matching cache file signature

--- a/ggmap/analyses.py
+++ b/ggmap/analyses.py
@@ -4232,9 +4232,12 @@ def _executor(jobname, cache_arguments, pre_execute, commands, post_execute,
             exp_finish_suffix = ""
             if array > 1:
                 exp_finish_suffix = str(int(i+1))
-            if (array == 1) and (settings.GRIDNAME == 'JLU'):
-                if use_grid:
-                    exp_finish_suffix = 'undefined'
+            if (array == 1):
+                if (settings.GRIDNAME == 'JLU'):
+                    if use_grid:
+                        exp_finish_suffix = 'undefined'
+                    else:
+                        exp_finish_suffix = '1'
                 else:
                     exp_finish_suffix = '1'
             if not os.path.exists('%s/finished.info%s' % (wd, exp_finish_suffix)):

--- a/ggmap/settings.py
+++ b/ggmap/settings.py
@@ -35,6 +35,8 @@ DEFAULTS = {'condaenv_qiime1': {'default': 'qiime_env',
             # is no longer necessary.
             'use_grid': {'default': True,
                          'variable_name': 'USE_GRID'},
+            # in systems with both: SGE and slurm, prefer slurm over SGE
+            'prefer_slurm': {'default': True, 'variable_name': 'PREFER_SLURM'},
             # some grids, like HPC@HHU "bill" compute time to projects
             # we have to specify with -A for qsub which project should be used.
             'grid_account': {'default': '',
@@ -108,6 +110,8 @@ def init(err=sys.stderr):
     DIR_CONDA = config['dir_conda']
     global USE_GRID
     USE_GRID = config['use_grid']
+    global PREFER_SLURM
+    PREFER_SLURM = config['prefer_slurm']
     global R_MODULE
     R_MODULE = config['R_module']
     global GRID_ACCOUNT
@@ -133,6 +137,10 @@ def init(err=sys.stderr):
     elif '.computational.bio.uni-giessen.de' in hostname:
         GRIDNAME = 'JLU'
         VARNAME_PBSARRAY = 'SGE_TASK_ID'
+        GRIDENGINE_BINDIR = '/usr/bin/'
+    elif hostname.endswith('.intra'):
+        GRIDNAME = 'JLU_SLURM'
+        VARNAME_PBSARRAY = 'SLURM_ARRAY_TASK_ID'
         GRIDENGINE_BINDIR = '/usr/bin/'
     else:
         GRIDNAME = 'LOCAL'

--- a/ggmap/snippets.py
+++ b/ggmap/snippets.py
@@ -1273,7 +1273,7 @@ def cluster_run(cmds, jobname, result, environment=None,
         else:
             slurm_script = "#!/bin/bash\n\n"
             slurm_script += '#SBATCH --job-name=cr_%s\n' % jobname
-            slurm_script += '#SBATCH --output=%s/%%A.log\n' % pwd
+            slurm_script += '#SBATCH --output=%s/slurmlog-%%x-%%A.%%a.log\n' % pwd
             slurm_script += '#SBATCH --partition=%s\n' % settings.GRID_ACCOUNT
             slurm_script += '#SBATCH --ntasks=1\n'
             slurm_script += '#SBATCH --cpus-per-task=%i\n' % ppn
@@ -1286,8 +1286,8 @@ def cluster_run(cmds, jobname, result, environment=None,
             slurm_script += 'srun uname -a\n'
 
             for cmd in cmds:
-                slurm_script += 'srun %s\n' % cmd.replace(
-                    '${%s}' % settings.VARNAME_PBSARRAY, '${SLURM_ARRAY_TASK_ID}')
+                slurm_script += '%s\n' % (cmd.replace(
+                    '${%s}' % settings.VARNAME_PBSARRAY, '${SLURM_ARRAY_TASK_ID}'))
             _, file_script = mkstemp(suffix='.slurm.sh')
             f = open(file_script, 'w')
             f.write(slurm_script)


### PR DESCRIPTION
- you can specify if you prefer Slurm over SGE in .ggmaprc: e.g. `prefer_slurm: true`
- new gridname `JLU_SLURM` added
- adapted conda mechanism to new slurm cluster (you should not need to do anything to .profile | .bash_profile, besides the normal `conda init bash`)