### PR TITLE
fix: avoid warning message in corr metadata

### DIFF
--- a/ggmap/correlations.py
+++ b/ggmap/correlations.py
@@ -188,7 +188,6 @@ def correlate_metadata(metadata,
     meta, all_columns = _clear_metadata(
         metadata, categorials, ordinals, intervals, dates, err,
         for_metadata_correlation=True)
-
     summary = dict()
     # start computing correlations
     # if err is not None:
@@ -237,6 +236,11 @@ def correlate_metadata(metadata,
             groups = [g.dropna().values
                       for n, g
                       in meta.groupby(column_a)[column_b]]
+
+            if any(len(group) <= 1 for group in groups):
+                print(f"Info: skipping correlation due to insufficient data: {column_a} vs {column_b}")
+                continue
+
             f_, p_ = f_oneway(*groups)
 
             df_n = len(np.hstack(groups)) - len(groups)


### PR DESCRIPTION
when metadata is correlated the case might happen that subgroups have 1 or less members, this results in a warning

The attached CSV files are in reality TSV files, but github doesn't allow tsv file ending

[example_metadata.csv](https://github.com/user-attachments/files/16781976/example_metadata.csv)
[correlation_metadata.TXT](https://github.com/user-attachments/files/16781982/correlation_metadata.TXT)
[correlated_metadata_result_table.csv](https://github.com/user-attachments/files/16781985/correlated_metadata_result_table.csv)


Example code:
```
res_corrmeta = correlate_metadata(
    prj_metadata_filtered[list(set(prj_metadata_filtered.columns) - set(cols_ignore))],
    categorials=list(cols_categorial),
    ordinals=cols_ordinal,
    dates=cols_date,
    intervals=list(cols_interval)
)
display(res_corrmeta[1])
```

Expected warning without the fix: 
[Screenshot from 2024-08-28 12-26-52](https://github.com/user-attachments/assets/f12c4fc5-0e8e-425c-b2fc-e9615392674e)


