### PR TITLE
Refactoring 2026

### DIFF
--- a/ggmap/__init__.py
+++ b/ggmap/__init__.py
@@ -1,2 +1,2 @@
 __credits__ = "https://github.com/sjanssen2/ggmap/..."
-__version__ = "0.1.0.dev0"
+__version__ = "0.2.0.dev0"

--- a/ggmap/analyses.py
+++ b/ggmap/analyses.py
@@ -27,6 +27,7 @@ from matplotlib.ticker import FuncFormatter
 from sklearn.model_selection import train_test_split
 from sklearn.ensemble import RandomForestClassifier
 from skbio import OrdinationResults
+import taxopy
 
 from skbio.stats.distance import DistanceMatrix
 from skbio.tree import TreeNode
@@ -5316,6 +5317,45 @@ We compiled a set of full length 16S rRNA sequences for all XXX isolates from YY
                      **executor_args)
 
 
+def _taxid2gglineage(taxid, taxdb:taxopy.core.TaxDb):
+    """Obtaining a GreenGenes like lineage string from NCBI taxids is surprisingly
+       complicated as e.g. higher ranks can be empty, not all taxa use same ranks, ...
+       I therefore here use "taxopy" to obtain a full lineage from a taxID and
+       then extract major ranks as used in GreenGenes.
+
+    Parameters
+    ----------
+    taxid : int
+        The NCBI taxonomy ID of the taxon for which the lineage shall be retrieved
+    taxdb : taxopy.core.TaxDb
+        An initialized taxopy.core.TaxDb object, i.e. loading according taxonomy SQL dump.
+
+    Returns
+    -------
+    pd.Series with index gg_lineage for one combined lineage string and one index per
+    RANK (except Isolate).
+    """
+    taxInfo = taxopy.Taxon(taxid, taxdb)
+    lineage = []
+    for rank in settings.RANKS[:-1]:
+        rank = rank.replace('Kingdom', 'Domain')
+        norm_rank = rank.lower()
+        if norm_rank in taxInfo._rank_name_dictionary.keys():
+            lineage.append((norm_rank[0], rank, taxInfo._rank_name_dictionary[norm_rank]))
+        else:
+            lineage.append((norm_rank[0], rank, ""))
+    # special treatment for viruses: we have a clash in lineage concepts between NCBI and GG
+    # as NCBI knows multiple ranks above "Kingdom/Domain" for viruses, i.e. kingdom, realm, acellular root
+    if ('acellular root' in taxInfo._rank_name_dictionary.keys()) and (taxInfo._rank_name_dictionary['acellular root'] == 'Viruses') and (lineage[0][-1] == ""):
+        lineage[0] = (lineage[0][0], lineage[0][1], taxInfo._rank_name_dictionary['acellular root'])
+    results = {
+        'gg_lineage': '; '.join(map(lambda x: '%s__%s' % (x[0], x[2]), lineage)),
+        'taxopy_lineage': '; '.join(['%s=%s' % (k,v) for k,v in taxInfo._rank_name_dictionary.items()])}
+    for x in lineage:
+        results[x[1]] = x[2]
+
+    return pd.Series(results)
+
 def blast_local(fp_query, fp_db, blast_type='blastn',
                 max_target_seqs=10, max_evalue='1e-5', outformat = '6 qseqid qaccver saccver sallseqid sgi pident length mismatch gapopen qstart qend sstart send evalue bitscore',
                 earlyfiltering=None, word_size=11,
@@ -5371,6 +5411,7 @@ def blast_local(fp_query, fp_db, blast_type='blastn',
 
     def pre_execute(workdir, args):
         pass
+
     def commands(workdir, ppn, args):
         commands = {'pre': [], 'main': [], 'post': []}
 
@@ -5393,17 +5434,11 @@ def blast_local(fp_query, fp_db, blast_type='blastn',
             os.path.abspath(fp_db),
             workdir
         ))
-        commands['main'].append('cat %s/blast.taxids.$var_num | cut -f %i -d ";" | /vol/jlab/bin/taxonkit --data-dir %s lineage --show-lineage-ranks > %s/lineage.$var_num' % (
-            workdir,
-            outformat_list.index('sallseqid'),
-            os.path.dirname(os.path.abspath(fp_db)),
-            workdir
-        ))
         commands['post'].append('cat %s/blastres.* > %s/final.blastres' % ( workdir, workdir))
         commands['post'].append('cat %s/blast.taxids.* | sort -u > %s/final.blast.taxids' % (workdir, workdir))
-        commands['post'].append('cat %s/lineage.* | sort -u > %s/final.lineage' % (workdir, workdir))
 
         return commands
+
     def post_execute(workdir, args):
         FLOAT_COLS = ['evalue', 'pident', 'length', 'bitscore']
         COL_TYPES = {field: float if field in FLOAT_COLS else str for field in outformat.split()}
@@ -5423,19 +5458,11 @@ def blast_local(fp_query, fp_db, blast_type='blastn',
         # load blastdbcmd table
         taxids = pd.read_csv('%s/final.blast.taxids' % workdir, sep=";", header=None, names=['accession', 'gi', 'ordinal_id', 'taxid'], index_col=0)
 
-        # load lineages
-        lineages = pd.read_csv("%s/final.lineage" % workdir, sep="\t", names=['taxid', 'lineage', 'ranks'], index_col=0)
-        for idx, row in lineages[pd.notnull(lineages['lineage'])].iterrows():
-            for (taxon, rank) in zip(row['lineage'].split(';'), row['ranks'].split(';')):
-                if rank in ['domain', 'phylum', 'class', 'order', 'family', 'genus', 'species']:
-                    lineages.loc[idx, rank] = taxon
-
-        # merge all three tables
-        merged = hits.merge(
-            taxids[['taxid']], left_on='saccver', right_index=True, how='left').merge(
-                lineages, left_on='taxid', right_index=True, how='left')
-
-        return merged #{'hits': hits, 'taxids': taxids, 'lineages': lineages}
+        taxdb = taxopy.TaxDb(nodes_dmp="%s/nodes.dmp" % os.path.dirname(fp_db), names_dmp="%s/names.dmp" % os.path.dirname(fp_db), merged_dmp="%s/merged.dmp" % os.path.dirname(fp_db))
+        # extend taxids table by gg lineage string and columns for gg ranks
+        taxids = pd.concat([taxids, taxids['taxid'].apply(lambda x: _taxid2gglineage(x, taxdb))], axis=1)
+        return {'hits': hits.merge(taxids, left_on='qaccver', right_index=True, how='left'),
+                'taxids': taxids}
 
     return _executor('blastn',
                      {'fp_query': os.path.abspath(fp_query),
@@ -5676,6 +5703,12 @@ def deblur(dir_fastqs:str, trimlength:int=150,
         with open('%s/expected_sample_names.txt' % workdir) as f:
             for line in f.readlines():
                 exp_samplenames.append(line.strip())
+
+        fps_parts = glob(os.path.join(workdir, 'chunked_results', 'deblur.logfile.*'))
+        results['logfiles'] = dict()
+        for fp_part in tqdm(fps_parts, "collecting %i chunked log-files" % len(fps_parts)):
+            with open(fp_part, 'r') as f:
+                results['logfiles'][int(os.path.basename(fp_part).split('.logfile.')[-1])] = f.readlines()
 
         for biomtype in ['all.biom', 'reference-hit.biom', 'reference-non-hit.biom']:
             fps_parts = glob(os.path.join(workdir, 'chunked_results', 'results_chunk_*', biomtype))

--- a/ggmap/analyses.py
+++ b/ggmap/analyses.py
@@ -17,6 +17,7 @@ from glob import glob
 from IPython.display import Image
 from tqdm import tqdm
 import warnings
+import operator
 
 import pandas as pd
 from pandas.api.types import is_numeric_dtype
@@ -35,8 +36,10 @@ from skbio import DNA
 from biom.table import Table
 from biom.util import biom_open
 
-from ggmap.snippets import (pandas2biom, cluster_run, biom2pandas, sync_counts_metadata, check_column_presents, adjust_saturation, collapseCounts_objects, get_conda_activate_cmd, plotTaxonomy)
+from ggmap.snippets import (pandas2biom, biom2pandas, sync_counts_metadata, check_column_presents, adjust_saturation, collapseCounts_objects, plotTaxonomy)
 from ggmap import settings
+from ggmap.execute import *
+from ggmap.execute import _executor
 import seaborn as sns
 import networkx as nx
 
@@ -369,6 +372,12 @@ def writeReferenceTree(fp_reftree, workdir, fix_zero_len_branches=False,
             workdir+'/reference.tree')
 
 
+def _update_metric_alpha(metric):
+    if metric == 'PD_whole_tree':
+        return 'faith_pd'
+    return metric
+
+
 def rarefaction_curves(counts,
                        metrics=["PD_whole_tree", "shannon", "observed_features"],
                        num_steps=20, reference_tree=None, max_depth=None,
@@ -629,12 +638,6 @@ def rarefy(counts, rarefaction_depth,
                      **executor_args)
 
 
-def _update_metric_alpha(metric):
-    if metric == 'PD_whole_tree':
-        return 'faith_pd'
-    return metric
-
-
 def alpha_diversity(counts, rarefaction_depth,
                     metrics=["PD_whole_tree", "shannon", "observed_features"],
                     num_iterations=10, reference_tree=None,
@@ -652,7 +655,7 @@ def alpha_diversity(counts, rarefaction_depth,
         Alpha diversity metrics to be computed.
     num_iterations : int
         Number of iterations to rarefy the input table.
-    reference_tree : str
+    reference_tree : str OR skbio.TreeNode
         Reference tree file name for phylogenetic metics like unifrac.
     executor_args:
         dry, use_grid, nocache, wait, walltime, ppn, pmem, timing, verbose
@@ -678,9 +681,14 @@ def alpha_diversity(counts, rarefaction_depth,
                 verbose = sys.stderr
             else:
                 verbose = executor_args['verbose']
-            writeReferenceTree(args['reference_tree'], workdir,
-                               fix_zero_len_branches, verbose=verbose,
-                               name_analysis='alpha_diversity')
+            if isinstance(args['reference_tree'], TreeNode):
+                if fix_zero_len_branches:
+                    raise ValueError("You provided a skbio.TreeNode NOT a filepath to a newick file. I cannot fix zero branch length issues four you!")
+                args['reference_tree'].write(workdir+'/reference.tree')
+            else:
+                writeReferenceTree(args['reference_tree'], workdir,
+                                   fix_zero_len_branches, verbose=verbose,
+                                   name_analysis='alpha_diversity')
 
     def commands(workdir, ppn, args):
         commands = {'pre': [], 'main': [], 'post': []}
@@ -783,14 +791,6 @@ def alpha_diversity(counts, rarefaction_depth,
                      **executor_args)
 
 
-def _update_metric_beta(metric):
-    if metric == 'bray_curtis':
-        return 'braycurtis'
-    elif metric == 'weighted_unifrac':
-        return 'weighted_normalized_unifrac'
-    return metric
-
-
 def beta_diversity(counts,
                    metrics=["unweighted_unifrac",
                             "weighted_unifrac",
@@ -821,6 +821,13 @@ def beta_diversity(counts,
     Returns
     -------
     Dict of Pandas.DataFrame, one per metric."""
+    def _update_metric_beta(metric):
+        if metric == 'bray_curtis':
+            return 'braycurtis'
+        elif metric == 'weighted_unifrac':
+            return 'weighted_normalized_unifrac'
+        return metric
+
     assert isinstance(counts, pd.DataFrame) or isinstance(counts, Table)
     if isinstance(counts, pd.DataFrame):
         counts = counts.fillna(0.0)
@@ -1241,427 +1248,6 @@ def sepp(counts, chunksize=10000, reference_database=settings.FILE_REFERENCE_SEP
                      ppn=ppn, pmem=pmem, walltime=walltime,
                      array=len(range(0, len(seqs), chunksize)),
                      environment=environment,
-                     **executor_args)
-
-
-def sepp_old(counts, chunksize=10000, reference=None, stopdecomposition=None,
-             ppn=20, pmem='50GB', walltime='12:00:00',
-             **executor_args):
-    """Tip insertion of deblur sequences into GreenGenes backbone tree.
-
-    Parameters
-    ----------
-    counts : Pandas.DataFrame | Pandas.Series
-        a) OTU counts in form of a Pandas.DataFrame.
-        b) If providing a Pandas.Series, we expect the index to be a fasta
-           headers and the colum the fasta sequences.
-    reference : str
-        Default: None.
-        Valid values are ['pynast']. Use a different alignment file for SEPP.
-    executor_args:
-        dry, use_grid, nocache, wait, walltime, ppn, pmem, timing, verbose
-    chunksize: int
-        Default: 30000
-        SEPP jobs seem to fail if too many sequences are submitted per job.
-        Therefore, we can split your sequences in chunks of chunksize.
-
-    Returns
-    -------
-    ???"""
-    def pre_execute(workdir, args):
-        chunks = range(0, seqs.shape[0], args['chunksize'])
-        for chunk, i in enumerate(chunks):
-            # write all deblur sequences into one file per chunk
-            file_fragments = workdir + '/sequences%s.mfa' % (chunk + 1)
-            f = open(file_fragments, 'w')
-            chunk_seqs = seqs.iloc[i:i + args['chunksize']]
-            for header, sequence in chunk_seqs.items():
-                f.write('>%s\n%s\n' % (header, sequence))
-            f.close()
-
-    def commands(workdir, ppn, args):
-        commands = []
-        commands.append('cd %s' % workdir)
-        ref = ''
-        if args['reference'] is not None:
-            ref = ' -r %s' % args['reference']
-        sdcomp = ''
-        if 'stopdecomposition' in args:
-            sdcomp = ' -M %f ' % args['stopdecomposition']
-        fp_sepp = '$CONDA_PREFIX/'
-        commands.append('%sbin/run-sepp.sh "%s/sequences%s.mfa" res${%s} -x %i %s %s -r %sshare/sepp/ref/RAxML_info-reference-gg-raxml-bl.info -b 1' % (
-            fp_sepp,
-            workdir,
-            '${%s}' % settings.VARNAME_PBSARRAY if len(range(0, seqs.shape[0], chunksize)) > 1 else '1',
-            settings.VARNAME_PBSARRAY,
-            ppn,
-            ref,
-            sdcomp,
-            fp_sepp))
-        return commands
-
-    def post_execute(workdir, args):
-        files_placement = sorted(
-            [workdir + '/' + file_placement
-             for file_placement in next(os.walk(workdir))[2]
-             if file_placement.endswith('_placement.json')])
-        if len(files_placement) > 1:
-            file_mergedplacements = workdir + '/merged_placements.json'
-            if not os.path.exists(file_mergedplacements):
-                sys.stderr.write("step 1) merging placement files: ")
-                fout = open(file_mergedplacements, 'w')
-                for i, file_placement in enumerate(files_placement):
-                    sys.stderr.write('.')
-                    fin = open(file_placement, 'r')
-                    write = i == 0
-                    for line in fin.readlines():
-                        if '"placements": [{' in line:
-                            write = True
-                            if i != 0:
-                                continue
-                        if '}],' in line:
-                            write = i+1 == len(files_placement)
-                        if write is True:
-                            fout.write(line)
-                    fin.close()
-                    if i+1 != len(files_placement):
-                        fout.write('    },\n')
-                        fout.write('    {\n')
-                fout.close()
-                sys.stderr.write(' done.\n')
-
-            sys.stderr.write("step 2) placing fragments into tree: ...")
-            # guppy ran for: and consumed 45 GB of memory for 2M, chunked 10k
-            # sepp benchmark:
-            # real	37m39.772s
-            # user	31m3.906s
-            # sys	3m49.602s
-            file_merged_tree = file_mergedplacements[:-5] +\
-                '.tog.relabelled.tre'
-            cluster_run([
-                'cd %s' % workdir,
-                '$CONDA_PREFIX/bin/guppy tog %s' %
-                file_mergedplacements,
-                'cat %s | python %s > %s' % (
-                    file_mergedplacements.replace('.json', '.tog.tre'),
-                    files_placement[0].replace('placement.json',
-                                               'rename-json.py'),
-                    file_merged_tree)],
-                environment='sepp',
-                jobname='guppy_rename',
-                result=file_merged_tree,
-                ppn=1, pmem='100GB', walltime='1:00:00', dry=False,
-                wait=True)
-            sys.stderr.write(' done.\n')
-        else:
-            file_merged_tree = files_placement[0].replace(
-                '.json', '.tog.relabelled.tre')
-
-        sys.stderr.write("step 3) reading skbio tree: ...")
-        tree = TreeNode.read(file_merged_tree, format='newick')
-        sys.stderr.write(' done.\n')
-
-        sys.stderr.write("step 4) use the phylogeny to det"
-                         "ermine tips lineage: ")
-        lineages = []
-        features = []
-        divisor = int(tree.count(tips=True) / min(10, tree.count(tips=True)))
-        for i, tip in enumerate(tree.tips()):
-            if i % divisor == 0:
-                sys.stderr.write('.')
-            if tip.name.isdigit():
-                continue
-
-            lineage = []
-            for ancestor in tip.ancestors():
-                try:
-                    float(ancestor.name)
-                except TypeError:
-                    pass
-                except ValueError:
-                    lineage.append(ancestor.name)
-
-            lineages.append("; ".join(reversed(lineage)))
-            features.append(tip.name)
-        sys.stderr.write(' done.\n')
-
-        # storing tree as newick string is necessary since large trees would
-        # result in too many recursions for the python heap :-/
-        newick = StringIO()
-        tree.write(newick)
-        return {'taxonomy': pd.DataFrame(data=lineages,
-                                         index=features,
-                                         columns=['taxonomy']),
-                'tree': newick.getvalue(),
-                'reference': args['reference']}
-
-    inp = sorted(counts.index)
-    if type(counts) == pd.Series:
-        # typically, the input is an OTU table with index holding sequences.
-        # However, if provided a Pandas.Series, we expect index are sequence
-        # headers and single column holds sequences.
-        inp = counts.sort_index()
-
-    def post_cache(cache_results):
-        newicks = []
-        for tree in cache_results['trees']:
-            newicks.append(TreeNode.read(StringIO(tree), format='newick'))
-        cache_results['trees'] = newicks
-        return cache_results
-
-    seqs = inp
-    if type(inp) != pd.Series:
-        seqs = pd.Series(inp, index=inp).sort_index()
-    args = {'seqs': seqs,
-            'reference': reference,
-            'chunksize': chunksize}
-    if stopdecomposition is not None:
-        args['stopdecomposition'] = stopdecomposition
-    return _executor('sepp',
-                     args,
-                     pre_execute,
-                     commands,
-                     post_execute,
-                     ppn=ppn, pmem=pmem, walltime=walltime,
-                     array=len(range(0, seqs.shape[0], chunksize)),
-                     **executor_args)
-
-
-def sepp_stepbystep(counts, reference=None,
-                    stopdecomposition=None,
-                    ppn=20, pmem='8GB', walltime='12:00:00',
-                    **executor_args):
-    """Step by Step version of SEPP to track memory consumption more closely.
-       Tip insertion of deblur sequences into GreenGenes backbone tree.
-
-    Parameters
-    ----------
-    counts : Pandas.DataFrame | Pandas.Series
-        a) OTU counts in form of a Pandas.DataFrame.
-        b) If providing a Pandas.Series, we expect the index to be a fasta
-           headers and the colum the fasta sequences.
-    reference : str
-        Default: None.
-        Valid values are ['pynast']. Use a different alignment file for SEPP.
-    executor_args:
-        dry, use_grid, nocache, wait, walltime, ppn, pmem, timing, verbose
-    chunksize: int
-        Default: 30000
-        SEPP jobs seem to fail if too many sequences are submitted per job.
-        Therefore, we can split your sequences in chunks of chunksize.
-
-    Returns
-    -------
-    ???"""
-    def pre_execute(workdir, args):
-        file_fragments = workdir + '/sequences.mfa'
-        f = open(file_fragments, 'w')
-        for header, sequence in seqs.items():
-            f.write('>%s\n%s\n' % (header, sequence))
-        f.close()
-        os.makedirs(workdir + '/sepp-tempssd/', exist_ok=True)
-
-    def commands(workdir, ppn, args):
-        commands = []
-        name = 'seppstepbysteprun'
-        dir_base = ('/home/sjanssen/miniconda3/envs/seppGG_py3/'
-                    'src/sepp-package/')
-        dir_tmp = workdir + '/sepp-tempssd/'
-
-        commands.append('cd %s' % workdir)
-
-        commands.append(
-            ('python %s -P %i -A %s -t %s -a %s -r %s -f %s -cp '
-             '%s/chpoint-%s -o %s -d %s -p %s '
-             '1>>%s/sepp-%s-out.log 2>%s/sepp-%s-err.log') % (
-                ('%ssepp/run_sepp.py' % dir_base),  # python script of SEPP
-                5000,  # problem size for tree
-                1000,  # problem size for alignment
-                # reference tree file
-                ('%sref/reference-gg-raxml-bl-rooted-relabelled.tre' %
-                    dir_base),
-                # reference alignment file
-                ('%sref/gg_13_5_ssu_align_99_pfiltered.fasta' % dir_base),
-                # reference info file
-                ('%sref/RAxML_info-reference-gg-raxml-bl.info' % dir_base),
-                workdir + '/sequences.mfa',  # sequence input file
-                dir_tmp,  # tmpdir
-                name,
-                name,
-                workdir,
-                dir_tmp,
-                workdir,
-                name,
-                workdir,
-                name))
-
-        commands.append(('%s/sepp/tools/bundled/Linux/guppy-64 tog %s/%s_plac'
-                         'ement.json') % (dir_base, workdir, name))
-        commands.append(('python %s/%s_rename-json.py < %s/%s_placement.tog.t'
-                         're > %s/%s_placement.tog.relabelled.tre') %
-                        (workdir, name, workdir, name, workdir, name))
-        commands.append(('%s/sepp/tools/bundled/Linux/guppy-64 tog --xml %s/%'
-                         's_placement.json') % (dir_base, workdir, name))
-        commands.append(('python %s/%s_rename-json.py < %s/%s_placement.tog.x'
-                         'ml > %s/%s_placement.tog.relabelled.xml') %
-                        (workdir, name, workdir, name, workdir, name))
-
-        return commands
-
-    def post_execute(workdir, args):
-        file_merged_tree = workdir +\
-            '/seppstepbysteprun_placement.tog.relabelled.tre'
-        sys.stderr.write("step 1/2) reading skbio tree: ...")
-        tree = TreeNode.read(file_merged_tree, format='newick')
-        sys.stderr.write(' done.\n')
-
-        sys.stderr.write("step 2/2) use the phylogeny to det"
-                         "ermine tips lineage: ")
-        lineages = []
-        features = []
-        divisor = int(tree.count(tips=True) / min(10, tree.count(tips=True)))
-        for i, tip in enumerate(tree.tips()):
-            if i % divisor == 0:
-                sys.stderr.write('.')
-            if tip.name.isdigit():
-                continue
-
-            lineage = []
-            for ancestor in tip.ancestors():
-                try:
-                    float(ancestor.name)
-                except TypeError:
-                    pass
-                except ValueError:
-                    lineage.append(ancestor.name)
-
-            lineages.append("; ".join(reversed(lineage)))
-            features.append(tip.name)
-        sys.stderr.write(' done.\n')
-
-        # storing tree as newick string is necessary since large trees would
-        # result in too many recursions for the python heap :-/
-        newick = StringIO()
-        tree.write(newick)
-        return {'taxonomy': pd.DataFrame(data=lineages,
-                                         index=features,
-                                         columns=['taxonomy']),
-                'tree': newick.getvalue(),
-                'reference': args['reference']}
-
-    inp = sorted(counts.index)
-    if type(counts) == pd.Series:
-        # typically, the input is an OTU table with index holding sequences.
-        # However, if provided a Pandas.Series, we expect index are sequence
-        # headers and single column holds sequences.
-        inp = counts.sort_index()
-
-    seqs = inp
-    if type(inp) != pd.Series:
-        seqs = pd.Series(inp, index=inp).sort_index()
-    return _executor('seppstep',
-                     {'seqs': seqs,
-                      'reference': reference},
-                     pre_execute,
-                     commands,
-                     post_execute,
-                     ppn=ppn, pmem=pmem, walltime=walltime,
-                     **executor_args)
-
-
-def sepp_git(counts,
-             ppn=20, pmem='8GB', walltime='12:00:00',
-             **executor_args):
-    """Latest git version of SEPP.
-       Tip insertion of deblur sequences into GreenGenes backbone tree.
-
-    Parameters
-    ----------
-    counts : Pandas.DataFrame | Pandas.Series
-        a) OTU counts in form of a Pandas.DataFrame.
-        b) If providing a Pandas.Series, we expect the index to be a fasta
-           headers and the colum the fasta sequences.
-    executor_args:
-        dry, use_grid, nocache, wait, walltime, ppn, pmem, timing, verbose
-
-    Returns
-    -------
-    ???"""
-    def pre_execute(workdir, args):
-        file_fragments = workdir + '/sequences.mfa'
-        f = open(file_fragments, 'w')
-        for header, sequence in seqs.iter():
-            f.write('>%s\n%s\n' % (header, sequence))
-        f.close()
-        os.makedirs(workdir + '/sepp-tempssd/', exist_ok=True)
-
-    def commands(workdir, ppn, args):
-        commands = []
-        commands.append('cd %s' % workdir)
-        commands.append('%srun-sepp.sh "%s" res -x %i' % (
-            ('/home/sjanssen/Benchmark_insertiontree/'
-             'Software/sepp/sepp-package/'),
-            workdir+'/sequences.mfa',
-            ppn))
-        return commands
-
-    def post_execute(workdir, args):
-        file_merged_tree = workdir +\
-            '/res_placement.tog.relabelled.tre'
-        sys.stderr.write("step 1/2) reading skbio tree: ...")
-        tree = TreeNode.read(file_merged_tree, format='newick')
-        sys.stderr.write(' done.\n')
-
-        sys.stderr.write("step 2/2) use the phylogeny to det"
-                         "ermine tips lineage: ")
-        lineages = []
-        features = []
-        divisor = int(tree.count(tips=True) / min(10, tree.count(tips=True)))
-        for i, tip in enumerate(tree.tips()):
-            if i % divisor == 0:
-                sys.stderr.write('.')
-            if tip.name.isdigit():
-                continue
-
-            lineage = []
-            for ancestor in tip.ancestors():
-                try:
-                    float(ancestor.name)
-                except TypeError:
-                    pass
-                except ValueError:
-                    lineage.append(ancestor.name)
-
-            lineages.append("; ".join(reversed(lineage)))
-            features.append(tip.name)
-        sys.stderr.write(' done.\n')
-
-        # storing tree as newick string is necessary since large trees would
-        # result in too many recursions for the python heap :-/
-        newick = StringIO()
-        tree.write(newick)
-        return {'taxonomy': pd.DataFrame(data=lineages,
-                                         index=features,
-                                         columns=['taxonomy']),
-                'tree': newick.getvalue()}
-
-    inp = sorted(counts.index)
-    if type(counts) == pd.Series:
-        # typically, the input is an OTU table with index holding sequences.
-        # However, if provided a Pandas.Series, we expect index are sequence
-        # headers and single column holds sequences.
-        inp = counts.sort_index()
-
-    seqs = inp
-    if type(inp) != pd.Series:
-        seqs = pd.Series(inp, index=inp).sort_index()
-    return _executor('seppgit',
-                     {'seqs': seqs},
-                     pre_execute,
-                     commands,
-                     post_execute,
-                     environment='sepp_git',
-                     ppn=ppn, pmem=pmem, walltime=walltime,
                      **executor_args)
 
 
@@ -2792,8 +2378,13 @@ def correlation_diversity_metacolumns(metadata, categorial, alpha_diversities,
             ((alpha_diversities is not None) and (len(idx_samples) < alpha_diversities.shape[0])) |\
             any([len(idx_samples) < m.shape[0]
                  for m in beta_diversities.values()]):
-        sys.stderr.write(
-            'Reducing analysis to %i samples.\n' % len(idx_samples))
+        verbose = sys.stderr
+        if 'verbose' in executor_args.keys():
+            if executor_args['verbose'] is None:
+                verbose = None
+        if verbose is not None:
+            verbose.write(
+                'Reducing analysis to %i samples.\n' % len(idx_samples))
 
     idx_samples = list(idx_samples)
     # find columns that a) have only one value for all samples ...
@@ -4064,12 +3655,6 @@ def taxonomy(metadata : pd.DataFrame, counts : pd.DataFrame, taxonomy : pd.Serie
                      **executor_args)
 
 
-def _update_metric_alpha(metric):
-    if metric == 'PD_whole_tree':
-        return 'faith_pd'
-    return metric
-
-
 def scnic(counts: pd.DataFrame,
           method: str='sparcc',
           min_reads_per_feature: float=500,
@@ -4237,6 +3822,7 @@ def scnic(counts: pd.DataFrame,
                      array=1,
                      **executor_args)
 
+
 def ancom(counts: pd.DataFrame, rank, taxonomy: pd.Series, grouping: pd.Series, min_mean_abundance_per_feature: float=0.005,
           ppn=1, pmem='4GB', **executor_args):
     """Execute ANCOM analysis through Qiime2.
@@ -4281,7 +3867,7 @@ def ancom(counts: pd.DataFrame, rank, taxonomy: pd.Series, grouping: pd.Series, 
         raise ValueError("Rank cannot be empty, choose from %s or set to 'raw'." % settings.RANKS)
     if (taxonomy is None) and rank != 'raw':
         raise ValueError("You must provide a taxonomy pd.Series if 'rank' is not 'raw'!")
-    counts = collapseCounts_objects(counts, rank, taxonomy)[0]
+    counts = collapseCounts_objects(counts, rank, taxonomy, out=executor_args.get('verbose', None))[0]
 
     def pre_execute(workdir, args):
         def _is_numeric(element):
@@ -4356,7 +3942,7 @@ def ancom(counts: pd.DataFrame, rank, taxonomy: pd.Series, grouping: pd.Series, 
 
         return results
 
-    def post_cache(cache_results, palette=None, feature_order=None, hue_order=None):
+    def post_cache(cache_results, palette=None, feature_order=None, hue_order=None, title=None):
         feat_sigdiff = cache_results['results']['ancom'][cache_results['results']['ancom']['Reject null hypothesis']].index
 
         data = cache_results['results']['features'][
@@ -4372,7 +3958,8 @@ def ancom(counts: pd.DataFrame, rank, taxonomy: pd.Series, grouping: pd.Series, 
             'relAbundance': '>= %f mean rel. abundance' % min_mean_abundance_per_feature,
             'Reject null hypothesis': 'significantly different'
         })
-        display(report_taxa)
+        if executor_args.get('verbose', sys.stderr) is not None:
+            display(report_taxa)
 
         srt_feat = srt_feat[srt_feat >= min_mean_abundance_per_feature]
         if report_taxa[report_taxa['significantly different'] & report_taxa['>= %f mean rel. abundance' % min_mean_abundance_per_feature]].shape[0] > 0:
@@ -4383,6 +3970,9 @@ def ancom(counts: pd.DataFrame, rank, taxonomy: pd.Series, grouping: pd.Series, 
                 order=srt_feat.index if feature_order is None else feature_order,
                 hue_order=hue_order,
                 orient='h', ax=axes, palette=palette)
+            if title != None:
+                cache_results['plot'].set_title(title)
+                axes.legend(bbox_to_anchor=(1.1, 1.05), title=grouping.name)
             cache_results['results']['figure'] = fig
 
         cache_results['results']['reported_features'] = srt_feat
@@ -4402,6 +3992,7 @@ def ancom(counts: pd.DataFrame, rank, taxonomy: pd.Series, grouping: pd.Series, 
                      ppn=ppn,
                      pmem=pmem,
                      **executor_args)
+
 
 def tempted(counts: pd.DataFrame, sample_metadata: pd.DataFrame,
             pivot_samples: pd.Series, fp_results: str, infix: str="",
@@ -4976,6 +4567,7 @@ def decontam(counts_raw: pd.DataFrame, sample_metadata: pd.DataFrame, taxonomy: 
                      ppn=ppn,
                      pmem=pmem,
                      **executor_args)
+
 
 def QC(dir_fastqs:str,
        pattern_fwdfiles:str="*_R1_*.fastq.gz",
@@ -5726,8 +5318,18 @@ We compiled a set of full length 16S rRNA sequences for all XXX isolates from YY
 
 def blastn_local(fp_query, fp_db,
            max_target_seqs=10, max_evalue='1e-5', outformat = 'qseqid qaccver saccver sallseqid sgi pident length mismatch gapopen qstart qend sstart send evalue bitscore',
-           environment:str=settings.ISOLATEASVS_ENV, ppn=1, pmem='4GB', **executor_args):
-    """Local blast search against HUGE local databases."""
+           earlyfiltering=None, word_size=11, environment:str=settings.ISOLATEASVS_ENV, ppn=1, pmem='4GB', **executor_args):
+    """Local blast search against HUGE local databases.
+    Parameters
+    ----------
+    earlyfiltering : dict[str: threshold]
+        Default: False.
+        Hit file can get HUGE (> 15GB) which might break pandas. Try parsing partial files instead
+        with earlyfiltering = True.
+    word_site : int
+        Word size for high scoring segment pair of BLAST.
+    """
+
     num_parts = len(glob(fp_db + '*.nsq'))
     def pre_execute(workdir, args):
         pass
@@ -5737,7 +5339,8 @@ def blastn_local(fp_query, fp_db,
         commands['main'].append('var_num=`echo "${%s} - 1" | bc`; var_num=`printf "%%03d" $var_num`' % (
             settings.VARNAME_PBSARRAY
         ))
-        commands['main'].append('blastn -query %s -db %s.$var_num -out %s/blastres.$var_num -outfmt "6 %s" -max_target_seqs %i -evalue %s' % (
+        commands['main'].append('blastn -word_size %i -query %s -db %s.$var_num -out %s/blastres.$var_num -outfmt "6 %s" -max_target_seqs %i -evalue %s' % (
+            args['word_size'],
             os.path.abspath(fp_query),
             os.path.abspath(fp_db),
             workdir,
@@ -5762,20 +5365,29 @@ def blastn_local(fp_query, fp_db,
 
         return commands
     def post_execute(workdir, args):
-        # load blast hits
-        hits = pd.read_csv('%s/final.blastres' % workdir, sep="\t", dtype=str, names=outformat.split())
-        for f in ['evalue', 'pident', 'length', 'bitscore']:
-            if f in hits.columns:
-                hits[f] = hits[f].astype({'evalue': float, 'pident': float, 'length': float, 'bitscore': float}[f])
+        FLOAT_COLS = ['evalue', 'pident', 'length', 'bitscore']
+        COL_TYPES = {field: float if field in FLOAT_COLS else str for field in outformat.split()}
+
+        hits = []
+        if earlyfiltering is not None:
+            for fp_partialhits in tqdm(sorted(glob('%s/blastres.*' % workdir)), 'parsing blast hits in parts'):
+                phits = pd.read_csv(fp_partialhits, sep="\t", dtype=COL_TYPES, names=outformat.split())
+                for field in earlyfiltering.keys():
+                    phits = phits[earlyfiltering[field]['operator'](phits[field], earlyfiltering[field]['threshold'])]
+                hits.append(phits)
+            hits = pd.concat(hits)
+        else:
+            # load blast hits
+            hits = pd.read_csv('%s/final.blastres' % workdir, sep="\t", dtype=COL_TYPES, names=outformat.split())
 
         # load blastdbcmd table
         taxids = pd.read_csv('%s/final.blast.taxids' % workdir, sep=";", header=None, names=['accession', 'gi', 'ordinal_id', 'taxid'], index_col=0)
 
         # load lineages
         lineages = pd.read_csv("%s/final.lineage" % workdir, sep="\t", names=['taxid', 'lineage', 'ranks'], index_col=0)
-        for idx, row in lineages.iterrows():
+        for idx, row in lineages[pd.notnull(lineages['lineage'])].iterrows():
             for (taxon, rank) in zip(row['lineage'].split(';'), row['ranks'].split(';')):
-                if rank in ['domain', 'phylum', 'order', 'family', 'genus', 'species']:
+                if rank in ['domain', 'phylum', 'class', 'order', 'family', 'genus', 'species']:
                     lineages.loc[idx, rank] = taxon
 
         # merge all three tables
@@ -5790,6 +5402,7 @@ def blastn_local(fp_query, fp_db,
                       'fp_db': os.path.abspath(fp_db),
                       'max_target_seqs': max_target_seqs,
                       'max_evalue': max_evalue,
+                      'word_size': word_size,
                      },
                      pre_execute,
                      commands,
@@ -5939,6 +5552,7 @@ def trainGG138(fp_basedir_taxonomy='/vol/jlab/MicrobiomeAnalyses/References/gg_1
                      pmem=pmem,
                      **executor_args)
 
+
 def deblur(dir_fastqs:str, trimlength:int=150,
            pattern_fwdfiles:str="*_R1_001.fastq.gz",
            ppn=10, pmem:str='2GB', walltime='4:00:00',
@@ -6065,308 +5679,3 @@ def deblur(dir_fastqs:str, trimlength:int=150,
                      walltime=walltime,
                      array=len(chunks),
                      **executor_args)
-
-
-def _parse_timing(workdir, jobname):
-    """If existant, parses timing information.
-
-    Parameters
-    ----------
-    workdir : str
-        Path to tmp workdir of _executor containing cr_ana_<jobname>.t* file
-    jobname : str
-        Name of ran job.
-
-    Parameters
-    ----------
-    None if file could not be found. Otherwise: [str]
-    """
-    files_timing = [workdir + '/' + d
-                    for d in next(os.walk(workdir))[2]
-                    if 'cr_ana_%s.t' % jobname in d]
-    for file_timing in files_timing:
-        with open(file_timing, 'r') as content_file:
-            return content_file.readlines()
-        # stop after reading first found file, since there should only be one
-        break
-    return None
-
-
-def _md5(filepath):
-    """Returns md5sum of file path"""
-    hash_md5 = hashlib.md5()
-    with open(filepath, "rb") as f:
-        for chunk in iter(lambda: f.read(4096), b""):
-            hash_md5.update(chunk)
-    return hash_md5.hexdigest()
-
-
-def _executor(jobname, cache_arguments, pre_execute, commands, post_execute,
-              post_cache=None, post_cache_arguments=dict(),
-              dry=True, use_grid=True, ppn=10, nocache=False,
-              pmem='20GB', environment=settings.QIIME_ENV, walltime='4:00:00',
-              wait=True, timing=True, verbose=sys.stderr, array=1,
-              dirty=False):
-    """
-
-    Parameters
-    ----------
-    jobname : str
-    cache_arguments : []
-    pre_execute : function
-    commands : [] or dict:{'pre': [], 'main': [], 'post': []}
-    post_execute : function
-    post_cache : function
-        A function that is called, after results have been loaded from cache /
-        were generated. E.g. drawing rarefaction curves.
-    environment : str
-
-    ==template arguments that should be copied to calling analysis function==
-    dry : bool
-        Default: True.
-        If True: only prepare working directory and create necessary input
-        files and print the command that would be executed in a non dry run.
-        For debugging. Workdir is not deleted.
-        "pre_execute" is called, but not "post_execute".
-    use_grid : bool
-        Default: True.
-        If True, use qsub to schedule as a grid job, otherwise run locally.
-    nocache : bool
-        Default: False.
-        Normally, successful results are cached in .anacache directory to be
-        retrieved when called a second time. You can deactivate this feature
-        (useful for testing) by setting "nocache" to True.
-    wait : bool
-        Default: True.
-        Wait for results.
-    walltime : str
-        Default: "12:00:00".
-        hh:mm:ss formated wall runtime on cluster.
-    ppn : int
-        Default: 10.
-        Number of CPU cores to be used.
-    pmem : str
-        Default: '8GB'.
-        Resource request for cluster jobs. Multiply by ppn!
-    timing : bool
-        Default: True
-        Use '/usr/bin/time' to log run time of commands.
-    verbose : stream
-        Default: sys.stderr
-        To silence this function, set verbose=None.
-    array : int
-        Default: 1 = deactivated.
-        Only for Torque submits: make the job an array job.
-        You need to take care of correct use of ${PBS_JOBID} !
-    dirty : bool
-        Defaul: False.
-        If True, temporary working directory will not be removed.
-
-    Returns
-    -------
-    """
-    DIR_CACHE = '.anacache'
-    FILE_STATUS = 'finished.info'
-    results = {'results': None,
-               'workdir': None,
-               'qid': None,
-               'file_cache': None,
-               'cached_inputs': dict(),
-               'timing': None,
-               'cache_version': 20200826,
-               'created_on': None,
-               'conda_env': 'unknown',
-               'jobname': jobname}
-
-    # create an ID function if no post_cache function is supplied
-    def _id(x):
-        return x
-    if post_cache is None:
-        post_cache = _id
-
-    # phase 1: compute signature for cache file
-    # convert skbio.DistanceMatrix object to a sorted version of its data for
-    # hashing
-    cache_args_original = dict()
-    for arg in cache_arguments.keys():
-        if type(cache_arguments[arg]) == DistanceMatrix:
-            cache_args_original[arg] = cache_arguments[arg]
-            dm = cache_arguments[arg]
-            cache_arguments[arg] = dm.filter(sorted(dm.ids)).data
-        if (type(cache_arguments[arg]) == dict):
-            if (len({type(v) for v in cache_arguments[arg].values()} ^
-                    set([DistanceMatrix])) == 0):
-                cache_args_original[arg] = cache_arguments[arg]
-                cache_arguments[arg] = collections.OrderedDict(
-                    {k: dm.filter(sorted(dm.ids)).data
-                     for k, dm
-                     in cache_arguments[arg].items()})
-        if (type(cache_arguments[arg]) == pd.Series):
-            cache_args_original[arg] = cache_arguments[arg]
-            cache_arguments[arg] = cache_arguments[arg].sort_index()
-        if (type(cache_arguments[arg]) == pd.DataFrame):
-            cache_args_original[arg] = cache_arguments[arg]
-            cache_arguments[arg] = cache_arguments[arg].loc[
-                sorted(cache_arguments[arg].index),
-                sorted(cache_arguments[arg].columns)]
-        if isinstance(cache_arguments[arg], Table):
-            cache_args_original[arg] = cache_arguments[arg]
-            cache_arguments[arg] = sorted(list(cache_arguments[arg].ids('sample'))) + \
-                                   sorted(list(cache_arguments[arg].ids('observation'))) + \
-                                   [cache_arguments[arg].get_table_density()]
-        if (type(cache_arguments[arg]) == str) and os.path.exists(cache_arguments[arg]):
-            cache_args_original[arg] = cache_arguments[arg]
-            if os.path.isfile(cache_arguments[arg]):
-                # if argument can be used as a file path and the file actually exists...
-                # ... than use the md5sum of the file instead of the filepath for cache fingerprint
-                # Thus, moving the file will not affect the cache fingerprint
-                cache_arguments[arg] = _md5(cache_arguments[arg])
-            else:
-                # assume path is directory
-                cache_arguments[arg] = os.path.abspath(cache_arguments[arg])
-
-        # for better debugging, write hash sum for each input argument in result object
-        if cache_arguments[arg] is None:
-            results['cached_inputs'][arg] = None
-        else:
-             results['cached_inputs'][arg] = hashlib.md5(str(cache_arguments[arg]).encode()).hexdigest()
-
-    _input = collections.OrderedDict(sorted(cache_arguments.items()))
-    results['file_cache'] = "%s/%s.%s" % (DIR_CACHE, hashlib.md5(
-        str(_input).encode()).hexdigest(), jobname)
-
-    # convert back cache arguments if necessary
-    for arg in cache_args_original.keys():
-        cache_arguments[arg] = cache_args_original[arg]
-
-    # phase 2: if cache contains matching file, load from cache and return
-    if os.path.exists(results['file_cache']) and (nocache is not True):
-        if verbose:
-            verbose.write("Using existing results from '%s'. \n" %
-                          results['file_cache'])
-        f = open(results['file_cache'], 'rb')
-        results = pickle.load(f)
-        f.close()
-        return post_cache(results, **post_cache_arguments)
-
-    # phase 3: search in TMP dir if non-collected results are
-    # ready or are waited for
-    dir_tmp = tempfile.gettempdir()
-    if use_grid:
-        dir_tmp = os.environ['HOME'] + '/TMP/'
-        if not os.path.exists(dir_tmp):
-            raise ValueError('Temporary directory "%s" does not exist. '
-                             'Please create it and restart.' % dir_tmp)
-
-    # collect all tmp workdirs that contain the right cache signature
-    pot_workdirs = []
-    for _dir in next(os.walk(dir_tmp))[1]:
-        # a potential working directory needs to have the matching job name
-        if _dir.startswith('ana_%s_' % results['jobname']):
-            # for shared computers, make sure you have permission to read dir contents
-            if not os.access(os.path.join(dir_tmp, _dir), os.R_OK):
-                continue
-            potwd = os.path.join(dir_tmp, _dir)
-            # and a matching cache file signature
-            if results['file_cache'].split('/')[-1] in next(os.walk(potwd))[2]:
-                pot_workdirs.append(potwd)
-    finished_workdirs = []
-    for wd in pot_workdirs:
-        all_finished = os.path.exists('%s/finished.info' % wd)
-        # for i in range(array):
-        #     exp_finish_suffix = ""
-        #     if array > 1:
-        #         exp_finish_suffix = str(int(i+1))
-        #     if (array == 1):
-        #         if (settings.GRIDNAME == 'JLU'):
-        #             if use_grid:
-        #                 exp_finish_suffix = 'undefined'
-        #             else:
-        #                 exp_finish_suffix = '1'
-        #         else:
-        #             exp_finish_suffix = '1'
-        #     if not os.path.exists('%s/finished.info%s' % (wd, exp_finish_suffix)):
-        #         all_finished = False
-        #         break
-        if all_finished:
-            finished_workdirs.append(wd)
-    if len(pot_workdirs) > 0 and len(finished_workdirs) <= 0:
-        if verbose:
-            verbose.write(
-                ('Found %i temporary working directories, but non of '
-                 'them have finished (missing "finished.info" file). If no job is currently running,'
-                 ' you might want to delete these directories and res'
-                 'tart:\n  %s\n') % (len(pot_workdirs),
-                                     "\n  ".join(pot_workdirs)))
-        return results
-    if len(finished_workdirs) > 0:
-        # arbitrarily pick first found workdir
-        results['workdir'] = finished_workdirs[0]
-        if verbose:
-            verbose.write('found matching working dir "%s"\n' %
-                          results['workdir'])
-    else:
-        # create a temporary working directory
-        prefix = 'ana_%s_' % jobname
-        results['workdir'] = tempfile.mkdtemp(prefix=prefix, dir=dir_tmp)
-        if verbose:
-            verbose.write("Working directory is '%s', cachefile is '%s'. " %
-                          (results['workdir'], results['file_cache']))
-        # leave an empty file in workdir with cache file name to later
-        # parse results from tmp dir
-        f = open("%s/%s" % (results['workdir'],
-                            results['file_cache'].split('/')[-1]), 'w')
-        f.close()
-
-        pre_execute(results['workdir'], cache_arguments)
-
-        lst_commands = commands(results['workdir'], ppn, cache_arguments)
-        # convert to new dict structure instead of flat list
-        if isinstance(lst_commands, list):
-            lst_commands = {'main': lst_commands, 'pre': [], 'post': []}
-        # device creation of a file _after_ execution of the job in workdir
-        final_cmd = 'touch %s/%s' % (results['workdir'], FILE_STATUS)
-        lst_commands['post'].append(final_cmd)
-
-        results['qid'] = cluster_run(
-            lst_commands, 'ana_%s' % jobname, results['workdir']+'mock',
-            environment, ppn=ppn, wait=wait, dry=dry,
-            pmem=pmem, walltime=walltime,
-            file_qid=results['workdir']+'/cluster_job_id.txt',
-            file_condaenvinfo=results['workdir']+'/conda_info.txt',
-            timing=timing,
-            file_timing=results['workdir']+('/timing${%s}.txt' % settings.VARNAME_PBSARRAY),
-            array=array, use_grid=use_grid)
-        if dry:
-            return results
-        if wait is False:
-            return results
-
-    results['results'] = post_execute(results['workdir'],
-                                      cache_arguments)
-    results['created_on'] = datetime.datetime.fromtimestamp(
-        time.time()).strftime('%Y-%m-%d %H:%M:%S')
-
-    results['conda_env'] = environment
-    if environment is not None:
-        with open(results['workdir']+'/conda_info.txt', 'r') as f:
-            results['conda_list'] = f.readlines()
-
-    results['timing'] = []
-    for timingfile in next(os.walk(results['workdir']))[2]:
-        if timingfile.startswith('timing'):
-            with open(results['workdir']+'/'+timingfile, 'r') as content_file:
-                results['timing'] += content_file.readlines()
-
-    if results['results'] is not None:
-        if not dirty:
-            shutil.rmtree(results['workdir'])
-            if verbose:
-                verbose.write(" Was removed.\n")
-
-    os.makedirs(os.path.dirname(results['file_cache']), exist_ok=True)
-    f = open(results['file_cache'], 'wb')
-    pickle.dump(results, f)
-    f.close()
-
-    return post_cache(results, **post_cache_arguments)

--- a/ggmap/correlations.py
+++ b/ggmap/correlations.py
@@ -3,6 +3,7 @@ import time
 from datetime import datetime
 import itertools
 import re
+import os
 
 import pandas as pd
 from pandas.errors import EmptyDataError
@@ -15,8 +16,11 @@ from skbio.stats.ordination import pcoa
 from skbio.tree import TreeNode
 from skbio import OrdinationResults
 from scipy.cluster.hierarchy import ward
+from tqdm import tqdm
+import inspect
+import textwrap
 
-from ggmap.analyses import _executor
+from ggmap.execute import _executor
 from ggmap import settings
 
 
@@ -47,7 +51,7 @@ def _get_pivot(field_a, field_b, metadata):
 
 
 def _clear_metadata(metadata,
-                    categorials=[], ordinals={}, intervals=[], dates={},
+                    categorials=[], ordinals={}, intervals=[], dates={}, omit=[],
                     err=sys.stderr,
                     for_metadata_correlation=False):
     """Clean up metadata and perform necessary conversions.
@@ -63,8 +67,14 @@ def _clear_metadata(metadata,
     # check that columns are distinct
     all_columns = set(categorials) | set(ordinals.keys()) |\
         set(intervals) | set(dates.keys())
+    # remove columns of user provided list "omit"
+    if len(omit) > 0:
+        all_columns -= set(omit)
+        if err:
+            print("You decided that following %i column%s will be omitted:\n  - %s" % (len(omit), 's' if len(omit) > 1 else '', '\n  - '.join(sorted(omit))), file=err)
+
     if len(all_columns) < (len(set(categorials)) + len(set(ordinals.keys())) +
-                           len(set(intervals)) + len(set(dates.keys()))):
+                           len(set(intervals)) + len(set(dates.keys())) - len(set(omit))):
         col_usage = pd.Series(categorials + list(ordinals.keys()) +\
                               intervals + list(dates.keys())).value_counts()
         display(col_usage[col_usage > 1])
@@ -119,7 +129,7 @@ def _clear_metadata(metadata,
     # https://docs.python.org/3/library/datetime.html
     def _convdate(date, frmt):
         if pd.isnull(date):
-            return 0
+            return 0.0
         if type(date) == float:
             return date
         elif type(date) == pd.Timestamp:
@@ -128,9 +138,16 @@ def _clear_metadata(metadata,
             try:
                 return time.mktime(datetime.strptime(date, frmt).timetuple())
             except ValueError:
-                return pd.NaT
+                try:
+                    return datetime.fromisoformat(date).timestamp()
+                except ValueError:
+                    return np.nan
+
     for column in dates.keys():
+        states_pre_convert = meta[column].dropna().unique()
         meta[column] = meta[column].apply(lambda x: _convdate(x, dates[column]))
+        if (meta[column].dropna().unique().shape[0] <= 1) and (len(states_pre_convert) > 1):
+            raise ValueError("Applying date format %s to your metadata column %s fails, as now all values are %s" % (dates[column], column, meta[column].dropna().unique()))
             #lambda x: time.mktime(datetime.strptime(
             #    x, dates[column]).timetuple()) if type(x) != float else x)
 
@@ -152,6 +169,53 @@ def _clear_metadata(metadata,
             meta[column] = meta[column].dropna().apply(
                 lambda x: ordinals[column].index(x)
                 if x in ordinals[column] else np.nan)
+
+    # omit columns which are either constant or have a different value for every single sample
+    omit_constant = []
+    omit_alldiff = []
+    for column in all_columns:
+        if meta[column].dropna().unique().shape[0] <= 1:
+            omit_constant.append(column)
+        elif meta[column].dropna().unique().shape[0] == meta[column].dropna().shape[0]:
+            omit_alldiff.append(column)
+    if len(omit_constant) > 0:
+        if err:
+            print("The following %i column%s will be omitted, as they are CONSTANT for every sample:\n  - %s" % (len(omit_constant), 's' if len(omit_constant) > 1 else '', '\n  - '.join(sorted(omit_constant))), file=err)
+    if len(omit_alldiff) > 0:
+        if err:
+            print("The following %i column%s will be omitted, as they are DIFFERENT for every sample:\n  - %s" % (len(omit_alldiff), 's' if len(omit_alldiff) > 1 else '', '\n  - '.join(sorted(omit_alldiff))), file=err)
+    all_columns = [column for column in all_columns
+                   if column not in omit_constant
+                   if column not in omit_alldiff]
+
+    omit_duplicates = set([])
+    for a in tqdm(range(len(all_columns)), 'determin redundant columns', disable=err is None):
+        col_a = all_columns[a]
+        if col_a in omit_duplicates:
+            continue
+        for b in range(a + 1, len(all_columns)):
+            col_b = all_columns[b]
+            if col_b in omit_duplicates:
+                continue
+            # columns are exact same values
+            drop_col = col_a
+            if col_b > col_a:
+                drop_col = col_b
+            if (meta[col_a] == meta[col_b]).all():
+            #if meta[[col_a, col_b]].T.drop_duplicates().shape[0] < 2:
+                omit_duplicates |= set([drop_col])
+            # columns have diff values, but there is a 1:1 mapping
+            if meta.fillna('?').groupby([col_a, col_b]).size().shape[0] == meta[col_a].fillna('?').unique().shape[0] == meta[col_b].fillna('?').unique().shape[0]:
+                omit_duplicates |= set([drop_col])
+    if len(omit_duplicates) > 0:
+        if err:
+            print("The following %i column%s will be omitted, as they are REDUNDANT to other columns:\n  - %s" % (len(omit_duplicates), 's' if len(omit_duplicates) > 1 else '', '\n  - '.join(sorted(list(omit_duplicates)))), file=err)
+    all_columns = [column for column in all_columns
+                   if column not in omit_duplicates]
+
+    if len(all_columns) < min_col_nr:
+        raise ValueError('After filtering columns, only %i column remains, which is too little for this type of analysis! Need to be %i' %
+                         (len(all_columns), min_col_nr))
 
     return meta, all_columns
 
@@ -186,15 +250,19 @@ def correlate_metadata(metadata,
     fig, correlations : pd.DataFrame , tree : skbio.tree.TreeNode
     """
     meta, all_columns = _clear_metadata(
-        metadata, categorials, ordinals, intervals, dates, err,
+        metadata, categorials=categorials, ordinals=ordinals, intervals=intervals, dates=dates, err=err,
         for_metadata_correlation=True)
+    categorials = [c for c in categorials if c in all_columns]
+    intervals = [c for c in intervals if c in all_columns]
+    ordinals = {c: v for c, v in ordinals.items() if c in all_columns}
+    dates = {c: v for c, v in dates.items() if c in all_columns}
 
     summary = dict()
     # start computing correlations
     # if err is not None:
     #     err.write('correlations intra categorial\n')
     for (column_a, column_b) in itertools.combinations(categorials, 2):
-        pivot = _get_pivot(column_a, column_b, meta).values
+        pivot = _get_pivot(column_a, column_b, meta[all_columns]).values
 
         if (pivot.shape[0] > 1) & (pivot.shape[1] > 1):
             chi2, p, _, _ = chi2_contingency(pivot)
@@ -274,7 +342,186 @@ def correlate_metadata(metadata,
     return fig, correlations, tree
 
 
-def redundancy_analysis_alpha(metadata, alpha,
+CODE_CLAUDE = r"""
+# -- Helper: get complete rows for a given set of variables -----------------
+get_complete_rows <- function(predictors, data) {
+  cols_needed <- c(vars_diversity, predictors)
+  complete.cases(data[, cols_needed, drop = FALSE])
+}
+
+# -- Helper: count degrees of freedom on the filtered subset ---------------
+count_df <- function(predictors, data) {
+  rows <- get_complete_rows(predictors, data)
+  sub  <- data[rows, , drop = FALSE]
+  total <- 0
+  for (v in predictors) {
+    col <- sub[[v]]
+    if (is.factor(col)) {
+      col <- droplevels(col)
+      total <- total + nlevels(col) - 1
+    } else {
+      total <- total + 1
+    }
+  }
+  total
+}
+
+# -- Helper: safely compute adjusted R² ------------------------------------
+get_r2 <- function(predictors, data) {
+  rows <- get_complete_rows(predictors, data)
+  sub  <- data[rows, , drop = FALSE]
+  sub  <- droplevels(sub)
+
+  n_obs   <- sum(rows)
+  df_used <- count_df(predictors, data)
+
+  if (n_obs < 10) return(NA)
+  if (df_used >= n_obs - 1) return(NA)
+
+  formula_str <- paste("sub[, vars_diversity] ~", paste(predictors, collapse = " + "))
+
+  result <- tryCatch({
+    mod <- rda(as.formula(formula_str), data = sub)
+    if (is.null(mod$CA) || mod$CA$tot.chi == 0) return(NA)
+    RsquareAdj(mod)$adj.r.squared
+  }, warning = function(w) {
+    if (grepl("overfitted", conditionMessage(w))) return(NA)
+    tryCatch({
+      mod <- rda(as.formula(formula_str), data = sub)
+      RsquareAdj(mod)$adj.r.squared
+    }, error = function(e) NA)
+  }, error = function(e) NA)
+
+  if (is.null(result) || length(result) != 1) return(NA_real_)
+  result
+}
+
+# -- Step 1: test each variable individually --------------------------------
+cat("=== Step 1: Individual variance explained per variable ===\n")
+
+single_r2 <- sapply(vars_meta, function(v) {
+  rows <- get_complete_rows(v, meta_diversity)
+  r2   <- get_r2(v, meta_diversity)
+  df   <- count_df(v, meta_diversity)
+  cat(sprintf("  %-45s | n=%d | df=%d | R²adj=%s\n",
+              v, sum(rows), df,
+              ifelse(is.na(r2), "NA (overfitted/error)", sprintf("%.4f", r2))))
+  r2
+})
+
+single_r2_df <- data.frame(
+  variable = names(single_r2),
+  R2adj    = single_r2,
+  n        = sapply(vars_meta, function(v) sum(get_complete_rows(v, meta_diversity))),
+  df_used  = sapply(vars_meta, count_df, data = meta_diversity)
+)
+single_r2_df <- single_r2_df[order(-single_r2_df$R2adj, na.last = TRUE), ]
+
+cat("\nRanking of individual variables:\n")
+print(single_r2_df)
+
+# -- Forward selection ------------------------------------------------------
+usable_vars <- names(single_r2)[!is.na(single_r2)]
+cat(sprintf("\n%d of %d variables are usable\n", length(usable_vars), length(vars_meta)))
+
+selected   <- c()
+remaining  <- usable_vars
+results    <- list()
+current_r2 <- 0
+
+cat("\n=== Forward selection ===\n")
+
+repeat {
+  if (length(remaining) == 0) break
+
+  candidate_r2 <- sapply(remaining, function(v) {
+    get_r2(c(selected, v), meta_diversity)
+  })
+
+  valid <- !is.na(candidate_r2)
+  if (!any(valid)) {
+    cat("  -> No further valid variables. Selection stopped.\n")
+    break
+  }
+
+  best_idx <- which.max(candidate_r2)
+  best_var <- remaining[best_idx]
+  best_r2  <- candidate_r2[best_idx]
+  gain     <- best_r2 - current_r2
+  n_used   <- sum(get_complete_rows(c(selected, best_var), meta_diversity))
+
+  cat(sprintf("Step %d | %-45s | n=%d | R²adj=%.4f | gain=%.4f\n",
+              length(selected) + 1, best_var, n_used, best_r2, gain))
+
+  if (gain <= 1e-6) {
+    cat("  -> No further increase. Selection stopped.\n")
+    break
+  }
+
+  selected   <- c(selected, best_var)
+  remaining  <- setdiff(remaining, best_var)
+  current_r2 <- best_r2
+
+  results[[length(results) + 1]] <- data.frame(
+    step     = length(selected),
+    variable = best_var,
+    n        = n_used,
+    R2adj    = best_r2,
+    R2_gain  = gain
+  )
+
+  if (length(remaining) == 0) break
+}
+
+# -- Output -----------------------------------------------------------------
+if (length(results) > 0) {
+  result_df <- do.call(rbind, results)
+  cat("\n=== Result of forward selection ===\n")
+  print(result_df)
+  write.table(result_df,
+              file = paste0(workdir, '/forward_selection_result_', metric_name, '.tsv'),
+              quote = FALSE, sep = '\t', col.names = NA)
+  vars_meta <- rownames(result_df)
+} else {
+  cat("\nNo variable could be selected.\n")
+  vars_meta <- NULL
+}
+
+write.table(single_r2_df,
+            file = paste0(workdir, '/single_variable_r2_', metric_name, '.tsv'),
+            quote = FALSE, sep = '\t', col.names = NA)
+
+cols_needed   <- c(vars_diversity, vars_meta)
+complete_rows <- complete.cases(meta_diversity[, cols_needed])
+meta_diversity      <- droplevels(meta_diversity[complete_rows, ])
+
+cat(sprintf("\nn = %d samples for ordiR2step\n", nrow(meta_diversity)))
+
+"""
+def _read_single_variable_r2(workdir, metric_name):
+    fp_singlevar = '%s/single_variable_r2_%s.tsv' % (workdir, metric_name)
+    if os.path.exists(fp_singlevar):
+        df = pd.read_csv(fp_singlevar, sep="\t", index_col=0)
+        del df['variable']
+        df = df.rename(columns={'n': 'number_samples',
+                                'df_used': 'number_states'})
+        df.index.name = 'covariate'
+        return df
+    else:
+        return None
+
+def _read_forward_selection(workdir, metric_name):
+    fp_fwd_sel = '%s/forward_selection_result_%s.tsv' % (workdir, metric_name)
+    if os.path.exists(fp_fwd_sel):
+        df = pd.read_csv(fp_fwd_sel, sep="\t", index_col=0)
+        del df['variable']
+        df = df.rename(columns={'n': 'number_samples'})
+        df.index.name = 'covariate'
+        return df
+    else:
+        return None
+
+def redundancy_analysis_alpha(metadata, alpha, auto=False,
                               categorials=[], ordinals={}, intervals=[],
                               dates={}, title=None, colors=None, ax=None,
                               **executor_args):
@@ -286,6 +533,10 @@ def redundancy_analysis_alpha(metadata, alpha,
         DataFrame holding all metadata about an experiment.
     alpha : Pandas.Series
         Series holding alpha diversity values for every sample.
+    auto : Boolean
+        Default: False
+        If True, we take all metadata columns and iteratively try to compose
+        a model that explains most of the variability.
     categorials : [str]
         List of column names of provided metadata DataFrame.
     ordinals : dict{str, None | [str]}
@@ -317,6 +568,11 @@ def redundancy_analysis_alpha(metadata, alpha,
     def pre_execute(workdir, args):
         COL_NAME_ALPHA = 'forRDA_alpha'
 
+        # if user choose "auto", we make all metadata columns to "categorials" if not otherise
+        # classified as ordinals, intervals or dates
+        if (auto is True) and (len(args['categorials']) <= 0):
+            args['categorials'] = list(set(args['metadata'].columns) - set(args['ordinals'].keys()) - set(args['intervals']) - set(args['dates'].keys()))
+
         # samples = set(args['metadata'].index) & set(args['alpha'].index)
         meta, all_columns = _clear_metadata(
             args['metadata'], args['categorials'], args['ordinals'],
@@ -332,37 +588,43 @@ def redundancy_analysis_alpha(metadata, alpha,
                 % (args['metadata'].shape[0], args['alpha'].shape[0],
                    meta_alpha.shape[0]))
 
-        meta_alpha.to_csv('%s/metadata_alpha.tsv' % workdir, sep="\t",
+        meta_alpha.to_csv('%s/metadata_alpha_%s.tsv' % (workdir, args['alpha'].name), sep="\t",
                           index=False)
-        with open('%s/rscript.R' % workdir, 'w') as f:
+        with open('%s/rscript_%s.R' % (workdir, args['alpha'].name), 'w') as f:
             f.write('library(vegan)\n')
-            f.write('meta_alpha = read.csv(\'%s/metadata_alpha.tsv\', '
-                    'stringsAsFactors=FALSE, sep=\'\\t\')\n' % workdir)
-            f.write('vars_cat = c(\'%s\')\n' %
-                    "', '".join(categorials + list(ordinals.keys())))
-            f.write('meta_alpha[vars_cat] = lapply(meta_alpha[vars_cat],'
+            f.write("workdir <- '%s'\n" % workdir)
+            f.write("metric_name <- '%s'\n" % args['alpha'].name)
+            f.write('meta_diversity = read.csv(paste0(workdir, \'/metadata_alpha_\', metric_name, \'.tsv\'), '
+                    'stringsAsFactors=FALSE, sep=\'\\t\')\n')
+            f.write('vars_meta = c(\'%s\')\n' %
+                    "', '".join([c for c in sorted(args['categorials'] + list(args['ordinals'].keys())) if c in all_columns]))
+            f.write('meta_diversity[vars_meta] = lapply(meta_diversity[vars_meta],'
                     ' factor)\n')
-            f.write('meta_alpha = meta_alpha[complete.cases(meta_alpha), ]\n')
-            f.write('mod0 <- rda(meta_alpha$%s ~ 1., meta_alpha)  # Model with'
-                    ' intercept only\n' % COL_NAME_ALPHA)
-            f.write('mod1 <- rda(meta_alpha$%s ~ ., meta_alpha)  # Model with'
-                    ' all explanatory variables\n' % COL_NAME_ALPHA)
+            f.write('vars_diversity = c(\'%s\')\n' % COL_NAME_ALPHA)
+            if args['auto'] is True:
+                f.write(CODE_CLAUDE)
+                f.write('meta_diversity <- na.omit(meta_diversity[, cols_needed])\n')
+            else:
+                f.write('meta_diversity = meta_diversity[complete.cases(meta_diversity), ]\n')
+
+            f.write('mod0 <- rda(meta_diversity$%s ~ 1., meta_diversity)  # Model with intercept only\n' % COL_NAME_ALPHA)
+            f.write('mod1 <- rda(meta_diversity$%s ~ ., meta_diversity)  # Model with all explanatory variables\n' % COL_NAME_ALPHA)
             f.write('step.res <- ordiR2step(mod0, mod1, perm.max = 1000)\n')
-            f.write('write.table(step.res$anova, file=\'%s/result.tsv\', '
-                    'quote=FALSE, sep=\'\\t\', col.names = NA)\n' % workdir)
+            f.write('write.table(step.res$anova, file=paste0(workdir, \'/result_\', metric_name, \'.tsv\'), '
+                    'quote=FALSE, sep=\'\\t\', col.names = NA)\n')
 
     def commands(workdir, ppn, args):
         commands = []
 
-        if settings.GRIDNAME != 'JLU':
+        if (settings.GRIDNAME != 'JLU') and ('use_grid' in executor_args) and (executor_args['use_grid'] is True):
             commands.append('module load %s' % settings.R_MODULE)
-        commands.append('R --vanilla < %s/rscript.R' % workdir)
+        commands.append('R --vanilla < %s/rscript_%s.R > %s/rscript_%s.out 2> %s/rscript_%s.err' % (workdir, args['alpha'].name, workdir, args['alpha'].name, workdir, args['alpha'].name))
 
         return commands
 
     def post_execute(workdir, args):
         try:
-            rda = pd.read_csv('%s/result.tsv' % workdir, sep='\t', index_col=0)
+            rda = pd.read_csv('%s/result_%s.tsv' % (workdir, args['alpha'].name), sep='\t', index_col=0)
         except EmptyDataError:
             return {'table': pd.DataFrame()}
 
@@ -377,7 +639,9 @@ def redundancy_analysis_alpha(metadata, alpha,
 
         rda = rda.reset_index().rename(columns={'index': 'covariate'})
 
-        return {'table': rda}
+        return {'table': rda,
+                'single_variable_r2': _read_single_variable_r2(workdir, args['alpha'].name),
+                'forward_selection': _read_forward_selection(workdir, args['alpha'].name)}
 
     def post_cache(cache_results):
         if cache_results['results']['table'].shape[0] > 0:
@@ -417,7 +681,8 @@ def redundancy_analysis_alpha(metadata, alpha,
                       'categorials': categorials,
                       'ordinals': ordinals,
                       'intervals': intervals,
-                      'dates': dates},
+                      'dates': dates,
+                      'auto': auto},
                      pre_execute,
                      commands,
                      post_execute,
@@ -427,7 +692,7 @@ def redundancy_analysis_alpha(metadata, alpha,
                      **executor_args)
 
 
-def redundancy_analysis_beta(metadata, beta, metric_name,
+def redundancy_analysis_beta(metadata, beta, metric_name, auto=False,
                              categorials=[], ordinals={}, intervals=[],
                              dates={}, num_dimensions=10, title=None, seed=None,
                              colors=None, ax=None,
@@ -442,6 +707,10 @@ def redundancy_analysis_beta(metadata, beta, metric_name,
         Series holding alpha diversity values for every sample.
     metric_name : str
         Beta diversity metric name; only for printing a speaking label.
+    auto : Boolean
+        Default: False
+        If True, we take all metadata columns and iteratively try to compose
+        a model that explains most of the variability.
     categorials : [str]
         List of column names of provided metadata DataFrame.
     ordinals : dict{str, None | [str]}
@@ -479,6 +748,11 @@ def redundancy_analysis_beta(metadata, beta, metric_name,
     def pre_execute(workdir, args):
         COL_NAME_BETA = 'forRDA_beta'
 
+        # if user choose "auto", we make all metadata columns to "categorials" if not otherise
+        # classified as ordinals, intervals or dates
+        if (auto is True) and (len(args['categorials']) <= 0):
+            args['categorials'] = list(set(args['metadata'].columns) - set(args['ordinals'].keys()) - set(args['intervals']) - set(args['dates'].keys()))
+
         # samples = set(args['metadata'].index) & set(args['alpha'].index)
         meta, all_columns = _clear_metadata(
             args['metadata'], args['categorials'], args['ordinals'],
@@ -494,52 +768,59 @@ def redundancy_analysis_beta(metadata, beta, metric_name,
         dimred = dimred.iloc[:, :num_dimensions]
         dimred.columns = ['%s_%s' % (COL_NAME_BETA, c) for c in dimred.columns]
 
-        meta_beta = meta.loc[:, list(all_columns)].merge(
+        meta_diversity = meta.loc[:, list(all_columns)].merge(
             dimred, left_index=True, right_index=True)
         if args['metadata'].shape[0] != dimred.shape[0]:
             sys.stderr.write(
                 'You provided %s and %s samples in metadata and beta '
                 'respectively. Merging to %s samples for further analysis.\n'
                 % (args['metadata'].shape[0], dimred.shape[0],
-                   meta_beta.shape[0]))
+                   meta_diversity.shape[0]))
 
-        meta_beta.to_csv('%s/metadata_beta.tsv' % workdir, sep="\t",
-                         index=False)
-        with open('%s/rscript.R' % workdir, 'w') as f:
+        meta_diversity.to_csv('%s/metadata_beta_%s.tsv' % (workdir, args['metric_name']), sep="\t",
+                               index=False)
+
+        with open('%s/rscript_%s.R' % (workdir, args['metric_name']), 'w') as f:
             f.write('library(vegan)\n')
-            f.write('meta_beta = read.csv(\'%s/metadata_beta.tsv\', '
-                    'stringsAsFactors=FALSE, sep=\'\\t\')\n' % workdir)
+            f.write("workdir <- '%s'\n" % workdir)
+            f.write("metric_name <- '%s'\n" % args['metric_name'])
+            f.write('meta_diversity = read.csv(paste0(workdir, \'/metadata_beta_\', metric_name, \'.tsv\'), '
+                    'stringsAsFactors=FALSE, sep=\'\\t\')\n')
             f.write('vars_cat = c(\'%s\')\n' %
-                    "', '".join(categorials + list(ordinals.keys())))
-            f.write('vars_pcs = c(\'%s\')\n' %
+                    "', '".join([c for c in sorted(args['categorials'] + list(args['ordinals'].keys())) if c in all_columns]))
+            f.write('vars_diversity = c(\'%s\')\n' %
                     "', '".join([c for c in dimred.columns]))
             f.write('vars_meta = c(\'%s\')\n' %
-                    "', '".join(all_columns))
-            f.write('meta_beta[vars_cat] = lapply(meta_beta[vars_cat],'
-                    ' factor)\n')
-            f.write('meta_beta = meta_beta[complete.cases(meta_beta), ]\n')
-            f.write('mod0 <- rda(meta_beta[, vars_pcs] ~ 1., meta_beta[, '
+                    "', '".join(sorted(all_columns)))
+            f.write('meta_diversity[vars_cat] = lapply(meta_diversity[vars_cat],'
+                 ' factor)\n')
+            if args['auto'] is True:
+                f.write(CODE_CLAUDE)
+            else:
+                f.write('meta_diversity = meta_diversity[complete.cases(meta_diversity), ]\n')
+
+            f.write('mod0 <- rda(meta_diversity[, vars_diversity] ~ 1., meta_diversity[, '
                     'vars_meta])  # Model with intercept only\n')
-            f.write('mod1 <- rda(meta_beta[, vars_pcs] ~ ., meta_beta[, '
+            f.write('mod1 <- rda(meta_diversity[, vars_diversity] ~ ., meta_diversity[, '
                     'vars_meta])  # Model with all explanatory variables\n')
             if args['seed'] is not None:
                 f.write('set.seed(%i)\n' % args['seed'])
             f.write('step.res <- ordiR2step(mod0, mod1, perm.max = 1000)\n')
-            f.write('write.table(step.res$anova, file=\'%s/result.tsv\', '
-                    'quote=FALSE, sep=\'\\t\', col.names = NA)\n' % workdir)
+            f.write('write.table(step.res$anova, file=paste0(workdir, \'/result_\', metric_name, \'.tsv\'), '
+                    'quote=FALSE, sep=\'\\t\', col.names = NA)\n')
 
     def commands(workdir, ppn, args):
         commands = []
 
-        if settings.GRIDNAME != 'JLU':
+        if (settings.GRIDNAME != 'JLU_SLURM') and ('use_grid' in executor_args) and (executor_args['use_grid'] is True):
             commands.append('module load %s' % settings.R_MODULE)
-        commands.append('R --vanilla < %s/rscript.R' % workdir)
+        commands.append('R --vanilla < %s/rscript_%s.R > %s/rscript_%s.out 2> %s/rscript_%s.err' % (workdir, args['metric_name'], workdir, args['metric_name'], workdir, args['metric_name']))
 
         return commands
 
     def post_execute(workdir, args):
         try:
-            rda = pd.read_csv('%s/result.tsv' % workdir, sep='\t', index_col=0)
+            rda = pd.read_csv('%s/result_%s.tsv' % (workdir, args['metric_name']), sep='\t', index_col=0)
         except EmptyDataError:
             sys.stderr.write('No significant covariates found!\n')
             return {'table': pd.DataFrame()}
@@ -555,7 +836,10 @@ def redundancy_analysis_beta(metadata, beta, metric_name,
 
         rda = rda.reset_index().rename(columns={'index': 'covariate'})
 
-        return {'table': rda, 'seed': args['seed']}
+        return {'table': rda, 'seed': args['seed'],
+                'single_variable_r2': _read_single_variable_r2(workdir, args['metric_name']),
+                'forward_selection': _read_forward_selection(workdir, args['metric_name'])
+               }
 
     def post_cache(cache_results):
         if cache_results['results']['table'].shape[0] > 0:
@@ -600,7 +884,8 @@ def redundancy_analysis_beta(metadata, beta, metric_name,
                       'ordinals': ordinals,
                       'intervals': intervals,
                       'dates': dates,
-                      'seed': seed},
+                      'seed': seed,
+                      'auto': auto},
                      pre_execute,
                      commands,
                      post_execute,
@@ -609,6 +894,305 @@ def redundancy_analysis_beta(metadata, beta, metric_name,
                      environment=settings.QIIME2_ENV,
                      **executor_args)
 
+def _generateRcode_redundancy(div_type, diversity_columns:[str], metadata_columns:[str], metric_name, workdir, auto, seed=None):
+    assert div_type in ['alpha', 'beta']
+
+    code = []
+    code.append('library(vegan)')
+    code.append("workdir <- '%s'" % workdir)
+    code.append("metric_name <- '%s'" % metric_name)
+    code.append('meta = read.csv(paste0(workdir, \'/metadata.tsv\'), stringsAsFactors=FALSE, sep=\'\\t\', row.names = 1)')
+    code.append('vars_meta = colnames(meta)')
+    code.append('diversity = read.csv(paste0(workdir, \'/diversity_\', metric_name, \'.tsv\'), stringsAsFactors=FALSE, sep=\'\\t\', row.names = 1)')
+    code.append('vars_diversity = colnames(diversity)')
+    code.append('meta_diversity <- merge(meta, diversity, by = "row.names")')
+    code.append('meta_diversity[vars_meta] = lapply(meta_diversity[vars_meta], factor)')
+
+    if auto is True:
+        code.append(CODE_CLAUDE)
+        if div_type == 'alpha':
+            code.append('meta_diversity <- na.omit(meta_diversity[, cols_needed])')
+    else:
+        code.append('meta_diversity = meta_diversity[complete.cases(meta_diversity), ]')
+
+    code.append('if (length(vars_meta) > 1) {')
+    code.append('    mod0 <- rda(meta_diversity[, vars_diversity] ~ 1., meta_diversity[, vars_meta])  # Model with intercept only')
+    code.append('    mod1 <- rda(meta_diversity[, vars_diversity] ~  ., meta_diversity[, vars_meta])  # Model with all explanatory variables')
+    if seed is not None:
+        code.append('    set.seed(%i)' % seed)
+    code.append('    step.res <- ordiR2step(mod0, mod1, perm.max = 1000)')
+    code.append('    write.table(step.res$anova, file=paste0(workdir, \'/result_\', metric_name, \'.tsv\'), quote=FALSE, sep=\'\\t\', col.names = NA)')
+    code.append('}')
+
+    return '\n'.join(code)
+
+def redundancy(metadata: pd.DataFrame, alpha: pd.DataFrame, beta: dict[str: DistanceMatrix],
+               auto:bool=True,
+               categorials:[str]=[],
+               ordinals:dict[str: [str]]={}, intervals:str=[], dates:dict[str: [str]]={}, omit:[str]=[],
+               beta_axis:int=10, seed:int=None, palette:dict[str: str]=None,
+               **executor_args):
+    """Forward step redundancy analysis for Alpha- and Beta-Diversity.
+
+    Parameters
+    ----------
+    beta : dict(str: skbio.DistanceMatrix | skbio.OrdinationResults)
+        Dictionary of "metric_name": object, where object is
+        Beta diversity skbio.DistanceMatrix OR (if already pre-computed) OrdinationResults
+    auto : Bool
+        Default: True.
+        Uses a greedy heuristic to first determine column with most variance explained
+        and then iteratively addes columsn until total variance converges.
+    categorials : [str]
+        If auto is False, use these metadata columns as categorial variables.
+    ordinals : dict[str: [str]]
+        Metadata columns that shall be explicitely treated as ordinales, i.e.
+        you need to provide a total ordering.
+    intervals : [str]
+        Metadata columns that shall explicitely be treated as interval data, like age, bmi, ...
+    dates : dict[str: [str]]
+        Metadata columns that shall explicitely be converted as dates. You need
+        to provide the date format string like "%Y-%m-%d"
+    omit : [str]
+        List of metadata columns to be omitted in analysis.
+    beta_axis : int
+        Number of PCoA axis that shall be used.
+    seed : int
+        Random seed.
+    palette : dict[str: str]
+        A palette for coloring the resulting graphs.
+    """
+    metrics = []
+    if beta is not None:
+        for bmetric in beta.keys():
+            metrics.append([bmetric, 'beta', isinstance(beta[bmetric], DistanceMatrix)])
+    if alpha is not None:
+        for ametric in alpha.columns:
+            metrics.append([ametric, 'alpha', False])
+    verbose = executor_args.get('verbose', sys.stderr)
+
+    def generate_code_python_pcoa():
+        import sys
+        from skbio.stats.distance import DistanceMatrix
+        from skbio.stats.ordination import pcoa
+        workdir, bmetric, beta_axis = sys.argv[1:]
+        res = pcoa(DistanceMatrix.read('%s/distancematrix_%s.tsv' % (workdir, bmetric)))
+        res.samples.iloc[:, :int(beta_axis)].to_csv('%s/diversity_%s.tsv' % (workdir, bmetric), sep='\t', index_label='sample_name')
+
+    def pre_execute(workdir, args):
+        # if user choose "auto", we make all metadata columns to "categorials" if not otherise
+        # classified as ordinals, intervals or dates
+        if (auto is True) and (len(args['categorials']) <= 0):
+            args['categorials'] = list(set(args['metadata'].columns) - set(args['ordinals'].keys()) - set(args['intervals']) - set(args['dates'].keys()))
+
+        if args['alpha'] is not None:
+            metricsnames_in_metadata = (set(args['metadata'].columns) - set(args['omit'])) & set(args['alpha'].columns)
+            if len(metricsnames_in_metadata) > 0:
+                raise ValueError("Your metadata table contains the following %i columns, whose names collidate with your alpha diversity data!\n  - %s\n" % (len(metricsnames_in_metadata), '\n  - '.join(metricsnames_in_metadata)))
+
+        meta, all_columns = _clear_metadata(
+            args['metadata'], args['categorials'], args['ordinals'],
+            args['intervals'], args['dates'], args['omit'], for_metadata_correlation=False, err=verbose)
+
+        # sync samples in metadata, alpha- and beta-diversity
+        idx = {'meta': set(meta.index)}
+        if args['alpha'] is not None:
+            for ametric in args['alpha'].columns:
+                idx[ametric] = set(args['alpha'][ametric].dropna().index)
+        for bmetric in args['beta'].keys():
+            if isinstance(args['beta'][bmetric], OrdinationResults):
+                idx[bmetric] = set(args['beta'][bmetric].samples.index)
+                if args['beta'][bmetric].samples.shape[1] < args['beta_axis']:
+                    raise ValueError("Your provided ordination for metric '%s' has fewer dimensions than you requested with parameter beta_axis=%s" % (bmetric, args['beta_axis']))
+            elif isinstance(args['beta'][bmetric], DistanceMatrix):
+                idx[bmetric] = set(args['beta'][bmetric].ids)
+            else:
+                raise ValueError("Unknown data type for beta diversity metric '%s'" % bmetric)
+
+        idx_shared = idx['meta']
+        for metric in idx.keys():
+            if metric == 'meta':
+                continue
+            idx_shared &= idx[metric]
+        idx_shared = sorted(list(idx_shared))
+        if len(idx_shared) <= 0:
+            raise ValueError("There is no overlap between samples in your metadata and those in your alpha- and beta- diversity inputs!")
+        num_idx_diversities = min([len(v) for k, v in idx.items() if k != 'meta'])
+        if len(idx['meta']) != num_idx_diversities:
+            if verbose:
+                verbose.write(
+                    'You provided %s and %s samples in metadata and diversity objects, '
+                    'respectively. Merging to %s samples for further analysis.\n'
+                    % (args['metadata'].shape[0], num_idx_diversities, len(idx_shared)))
+
+        # write metadata to tmp file
+        args['metadata'].loc[idx_shared, all_columns].to_csv('%s/metadata.tsv' % workdir, sep="\t", index_label='sample_name')
+
+        # prepare R input sheets and R scripts
+        if beta is not None:
+            for bmetric in args['beta'].keys():
+                if isinstance(args['beta'][bmetric], OrdinationResults):
+                    args['beta'][bmetric].samples.rename(columns={c: '%s_%s' % (bmetric, c) for c in args['beta'][bmetric].samples.columns}).loc[idx_shared, :].iloc[:, :args['beta_axis']].to_csv('%s/diversity_%s.tsv' % (workdir, bmetric), sep="\t", index_label='sample_name')
+                elif isinstance(args['beta'][bmetric], DistanceMatrix):
+                    # pcoa will be computed as a step in the cluster script
+                    args['beta'][bmetric].filter(idx_shared).write('%s/distancematrix_%s.tsv' % (workdir, bmetric))
+                    with open('%s/pcoa_script_%s.py' % (workdir, bmetric), "w", encoding="utf-8") as f:
+                        code = textwrap.dedent(inspect.getsource(generate_code_python_pcoa))
+                        code += '\nif __name__ == "__main__":\n    generate_code_python_pcoa()\n'
+                        f.write(code + '\n')
+
+                with open('%s/rscript_%s.R' % (workdir, bmetric), 'w') as f:
+                    f.write(_generateRcode_redundancy(
+                        'beta',
+                        [], #['%s_%s' % (bmetric, c) for c in dimred.columns],
+                        [c for c in sorted(args['categorials'] + list(args['ordinals'].keys())) if c in all_columns],
+                        bmetric,
+                        workdir, args['auto'], seed=args['seed']))
+
+        if alpha is not None:
+            for ametric in args['alpha'].columns:
+                meta_alpha = meta.loc[:, list(all_columns)].merge(
+                    args['alpha'][ametric], left_index=True, right_index=True)
+
+                args['alpha'].loc[idx_shared, ametric].to_frame().to_csv('%s/diversity_%s.tsv' % (workdir, ametric), sep="\t", index_label='sample_name')
+
+                with open('%s/rscript_%s.R' % (workdir, ametric), 'w') as f:
+                    f.write(_generateRcode_redundancy(
+                        'alpha',
+                        [], #[ametric],
+                        [c for c in sorted(args['categorials'] + list(args['ordinals'].keys())) if c in all_columns],
+                        ametric,
+                        workdir, args['auto'], seed=args['seed']))
+
+        with open('%s/metrics.txt' % workdir, 'w') as f:
+            f.write('\n'.join(map(lambda x: '\t'.join(map(str, x)), metrics)))
+
+    def commands(workdir, ppn, args):
+        commands = {'pre': [], 'main': [], 'post': []}
+
+        commands['main'].append('var_info=`head -n ${%s} %s/metrics.txt | tail -n 1`' % (
+            settings.VARNAME_PBSARRAY, workdir))
+        commands['main'].append('var_metric=`echo "${var_info}" | cut -f 1`')
+        commands['main'].append('var_pcoa=`echo "${var_info}" | cut -f 3`')
+        if (settings.GRIDNAME != 'JLU_SLURM') and ('use_grid' in executor_args) and (executor_args['use_grid'] is True):
+            commands['main'].append('module load %s' % settings.R_MODULE)
+        commands['main'].append('if [ "${var_pcoa}" == "True" ]; then python %s/pcoa_script_${var_metric}.py "%s" "${var_metric}" "%s"; fi' % (workdir, workdir, str(args['beta_axis'])))
+        commands['main'].append('R --vanilla < %s/rscript_${var_metric}.R > %s/rscript_${var_metric}.out 2> %s/rscript_${var_metric}.err' % (
+            workdir, workdir, workdir))
+
+        return commands
+
+    def post_execute(workdir, args):
+        results = {'table': dict(), 'single_variable_r2': dict(), 'forward_selection': dict(),
+                   'seed': args['seed']}
+
+        for (metric, _, _) in metrics:
+            try:
+                rda = pd.read_csv('%s/result_%s.tsv' % (workdir, metric), sep='\t', index_col=0)
+
+                # drop fields not starting with a +, i.e. are <All variables> or <none>
+                rda = rda.loc[[idx for idx in rda.index if idx.startswith('+')], :]
+
+                # compute adjusted effect size
+                rda['effect size'] = rda['R2.adj'] - ([0] + list(rda['R2.adj'].values)[:-1])
+                rda.index = map(lambda x: x.replace('+ ', ''), rda.index)
+                rda = rda.reset_index().rename(columns={'index': 'covariate'})
+
+                results['table'][metric] = rda
+            except (EmptyDataError, FileNotFoundError):
+                #sys.stderr.write('No significant covariates found for %s!\n' % metric)
+                results['table'][metric] = pd.DataFrame()
+
+            results['single_variable_r2'][metric] = _read_single_variable_r2(workdir, metric)
+            results['forward_selection'][metric] = _read_forward_selection(workdir, metric)
+
+        return results
+
+    def post_cache(cache_results, palette=dict(), title=None):
+        cols = (1 if alpha is not None else 0) + (1 if beta is not None else 0)
+        rows = max(alpha.shape[1] if alpha is not None else 0,
+                   len(beta.keys()) if beta is not None else 0)
+
+        max_num_covariates = max(
+            [cache_results['results']['table'][metric].shape[0]
+             for metric in cache_results['results']['table'].keys()])
+
+        fig, axes = plt.subplots(rows, cols,
+                                 gridspec_kw={"wspace": 0.8, "hspace": 0.5},
+                                 figsize=(5 * cols, 1. * max_num_covariates * rows))
+
+        axmetrics = []
+        if cols == 1:
+            if rows == 1:
+                axes = np.array([axes])
+            if alpha is not None:
+                axmetrics.extend(list(zip(axes, alpha.columns)))
+            if beta is not None:
+                axmetrics.extend(list(zip(axes, beta.keys())))
+        elif cols == 2:
+            axmetrics.extend(list(zip(axes[:, 0], alpha.columns)))
+            axmetrics.extend(list(zip(axes[:, 1], beta.keys())))
+
+        # collect axes which are used to later clear those without data,
+        # happens if number of alpha and beta metrics differ
+        no_clear = []
+        for (ax, metric) in axmetrics:
+            if cache_results['results']['table'][metric].shape[0] > 0:
+                rda = cache_results['results']['table'][metric]
+                rda['label'] = rda['covariate'] + '\n' + rda['Pr(>F)'].apply(lambda x: '(p: %.3f)' % x)
+                rda['color'] = rda['covariate'].apply(lambda x: palette.get(x, sns.color_palette()[0]))
+                pltte = rda.set_index('label')['color'].to_dict()
+
+                sns.barplot(data=rda.reset_index(),
+                           x='effect size',
+                           hue='label',
+                           y='label',
+                           order=rda.sort_values('effect size', ascending=False)['label'],
+                           ax=ax,
+                           palette=pltte, legend=False,
+                           )
+                #ax.set_ylabel('covariate')
+                ax.set_ylabel("")
+                ax.set_title(metric)
+                no_clear.append(ax)
+                ax.set_ylim((ax.get_ylim()[-1] + max_num_covariates, ax.get_ylim()[-1]))
+            else:
+                ax.text(0.5, 0.5, 'No significant findings\nfor %s' % metric, ha='center')
+                #sys.stderr.write('No significant findings for %s.\n' % metric)
+
+        # remove unused axes
+        for ax in axes.flatten():
+            if ax not in no_clear:
+                ax.set_axis_off()
+
+        if title is not None:
+            fig.suptitle(title)
+
+        cache_results['results']['figure'] = fig
+
+        return cache_results
+
+    return _executor('redundancy',
+                     {'metadata': metadata,
+                      'alpha': alpha,
+                      'beta': beta,
+                      'auto': auto,
+                      'categorials': categorials,
+                      'ordinals': ordinals,
+                      'intervals': intervals,
+                      'dates': dates,
+                      'omit': omit,
+                      'beta_axis': beta_axis,
+                      'seed': seed,
+                     },
+                     pre_execute,
+                     commands,
+                     post_execute,
+                     post_cache,
+                     ppn=1,
+                     environment=settings.QIIME2_ENV,
+                     array=len(metrics),
+                     **executor_args)
 
 def adonis(metadata: pd.DataFrame, dm: DistanceMatrix,
            formula: str, strat: str=None, permutations: int=999, ppn=1,

--- a/ggmap/deprecated.py
+++ b/ggmap/deprecated.py
@@ -108,3 +108,424 @@ def _display_image_in_actual_size(filename):
     ax.imshow(im_data, cmap='gray')
 
     return fig
+
+
+def sepp_old(counts, chunksize=10000, reference=None, stopdecomposition=None,
+             ppn=20, pmem='50GB', walltime='12:00:00',
+             **executor_args):
+    """Tip insertion of deblur sequences into GreenGenes backbone tree.
+
+    Parameters
+    ----------
+    counts : Pandas.DataFrame | Pandas.Series
+        a) OTU counts in form of a Pandas.DataFrame.
+        b) If providing a Pandas.Series, we expect the index to be a fasta
+           headers and the colum the fasta sequences.
+    reference : str
+        Default: None.
+        Valid values are ['pynast']. Use a different alignment file for SEPP.
+    executor_args:
+        dry, use_grid, nocache, wait, walltime, ppn, pmem, timing, verbose
+    chunksize: int
+        Default: 30000
+        SEPP jobs seem to fail if too many sequences are submitted per job.
+        Therefore, we can split your sequences in chunks of chunksize.
+
+    Returns
+    -------
+    ???"""
+    def pre_execute(workdir, args):
+        chunks = range(0, seqs.shape[0], args['chunksize'])
+        for chunk, i in enumerate(chunks):
+            # write all deblur sequences into one file per chunk
+            file_fragments = workdir + '/sequences%s.mfa' % (chunk + 1)
+            f = open(file_fragments, 'w')
+            chunk_seqs = seqs.iloc[i:i + args['chunksize']]
+            for header, sequence in chunk_seqs.items():
+                f.write('>%s\n%s\n' % (header, sequence))
+            f.close()
+
+    def commands(workdir, ppn, args):
+        commands = []
+        commands.append('cd %s' % workdir)
+        ref = ''
+        if args['reference'] is not None:
+            ref = ' -r %s' % args['reference']
+        sdcomp = ''
+        if 'stopdecomposition' in args:
+            sdcomp = ' -M %f ' % args['stopdecomposition']
+        fp_sepp = '$CONDA_PREFIX/'
+        commands.append('%sbin/run-sepp.sh "%s/sequences%s.mfa" res${%s} -x %i %s %s -r %sshare/sepp/ref/RAxML_info-reference-gg-raxml-bl.info -b 1' % (
+            fp_sepp,
+            workdir,
+            '${%s}' % settings.VARNAME_PBSARRAY if len(range(0, seqs.shape[0], chunksize)) > 1 else '1',
+            settings.VARNAME_PBSARRAY,
+            ppn,
+            ref,
+            sdcomp,
+            fp_sepp))
+        return commands
+
+    def post_execute(workdir, args):
+        files_placement = sorted(
+            [workdir + '/' + file_placement
+             for file_placement in next(os.walk(workdir))[2]
+             if file_placement.endswith('_placement.json')])
+        if len(files_placement) > 1:
+            file_mergedplacements = workdir + '/merged_placements.json'
+            if not os.path.exists(file_mergedplacements):
+                sys.stderr.write("step 1) merging placement files: ")
+                fout = open(file_mergedplacements, 'w')
+                for i, file_placement in enumerate(files_placement):
+                    sys.stderr.write('.')
+                    fin = open(file_placement, 'r')
+                    write = i == 0
+                    for line in fin.readlines():
+                        if '"placements": [{' in line:
+                            write = True
+                            if i != 0:
+                                continue
+                        if '}],' in line:
+                            write = i+1 == len(files_placement)
+                        if write is True:
+                            fout.write(line)
+                    fin.close()
+                    if i+1 != len(files_placement):
+                        fout.write('    },\n')
+                        fout.write('    {\n')
+                fout.close()
+                sys.stderr.write(' done.\n')
+
+            sys.stderr.write("step 2) placing fragments into tree: ...")
+            # guppy ran for: and consumed 45 GB of memory for 2M, chunked 10k
+            # sepp benchmark:
+            # real	37m39.772s
+            # user	31m3.906s
+            # sys	3m49.602s
+            file_merged_tree = file_mergedplacements[:-5] +\
+                '.tog.relabelled.tre'
+            cluster_run([
+                'cd %s' % workdir,
+                '$CONDA_PREFIX/bin/guppy tog %s' %
+                file_mergedplacements,
+                'cat %s | python %s > %s' % (
+                    file_mergedplacements.replace('.json', '.tog.tre'),
+                    files_placement[0].replace('placement.json',
+                                               'rename-json.py'),
+                    file_merged_tree)],
+                environment='sepp',
+                jobname='guppy_rename',
+                result=file_merged_tree,
+                ppn=1, pmem='100GB', walltime='1:00:00', dry=False,
+                wait=True)
+            sys.stderr.write(' done.\n')
+        else:
+            file_merged_tree = files_placement[0].replace(
+                '.json', '.tog.relabelled.tre')
+
+        sys.stderr.write("step 3) reading skbio tree: ...")
+        tree = TreeNode.read(file_merged_tree, format='newick')
+        sys.stderr.write(' done.\n')
+
+        sys.stderr.write("step 4) use the phylogeny to det"
+                         "ermine tips lineage: ")
+        lineages = []
+        features = []
+        divisor = int(tree.count(tips=True) / min(10, tree.count(tips=True)))
+        for i, tip in enumerate(tree.tips()):
+            if i % divisor == 0:
+                sys.stderr.write('.')
+            if tip.name.isdigit():
+                continue
+
+            lineage = []
+            for ancestor in tip.ancestors():
+                try:
+                    float(ancestor.name)
+                except TypeError:
+                    pass
+                except ValueError:
+                    lineage.append(ancestor.name)
+
+            lineages.append("; ".join(reversed(lineage)))
+            features.append(tip.name)
+        sys.stderr.write(' done.\n')
+
+        # storing tree as newick string is necessary since large trees would
+        # result in too many recursions for the python heap :-/
+        newick = StringIO()
+        tree.write(newick)
+        return {'taxonomy': pd.DataFrame(data=lineages,
+                                         index=features,
+                                         columns=['taxonomy']),
+                'tree': newick.getvalue(),
+                'reference': args['reference']}
+
+    inp = sorted(counts.index)
+    if type(counts) == pd.Series:
+        # typically, the input is an OTU table with index holding sequences.
+        # However, if provided a Pandas.Series, we expect index are sequence
+        # headers and single column holds sequences.
+        inp = counts.sort_index()
+
+    def post_cache(cache_results):
+        newicks = []
+        for tree in cache_results['trees']:
+            newicks.append(TreeNode.read(StringIO(tree), format='newick'))
+        cache_results['trees'] = newicks
+        return cache_results
+
+    seqs = inp
+    if type(inp) != pd.Series:
+        seqs = pd.Series(inp, index=inp).sort_index()
+    args = {'seqs': seqs,
+            'reference': reference,
+            'chunksize': chunksize}
+    if stopdecomposition is not None:
+        args['stopdecomposition'] = stopdecomposition
+    return _executor('sepp',
+                     args,
+                     pre_execute,
+                     commands,
+                     post_execute,
+                     ppn=ppn, pmem=pmem, walltime=walltime,
+                     array=len(range(0, seqs.shape[0], chunksize)),
+                     **executor_args)
+
+
+def sepp_stepbystep(counts, reference=None,
+                    stopdecomposition=None,
+                    ppn=20, pmem='8GB', walltime='12:00:00',
+                    **executor_args):
+    """Step by Step version of SEPP to track memory consumption more closely.
+       Tip insertion of deblur sequences into GreenGenes backbone tree.
+
+    Parameters
+    ----------
+    counts : Pandas.DataFrame | Pandas.Series
+        a) OTU counts in form of a Pandas.DataFrame.
+        b) If providing a Pandas.Series, we expect the index to be a fasta
+           headers and the colum the fasta sequences.
+    reference : str
+        Default: None.
+        Valid values are ['pynast']. Use a different alignment file for SEPP.
+    executor_args:
+        dry, use_grid, nocache, wait, walltime, ppn, pmem, timing, verbose
+    chunksize: int
+        Default: 30000
+        SEPP jobs seem to fail if too many sequences are submitted per job.
+        Therefore, we can split your sequences in chunks of chunksize.
+
+    Returns
+    -------
+    ???"""
+    def pre_execute(workdir, args):
+        file_fragments = workdir + '/sequences.mfa'
+        f = open(file_fragments, 'w')
+        for header, sequence in seqs.items():
+            f.write('>%s\n%s\n' % (header, sequence))
+        f.close()
+        os.makedirs(workdir + '/sepp-tempssd/', exist_ok=True)
+
+    def commands(workdir, ppn, args):
+        commands = []
+        name = 'seppstepbysteprun'
+        dir_base = ('/home/sjanssen/miniconda3/envs/seppGG_py3/'
+                    'src/sepp-package/')
+        dir_tmp = workdir + '/sepp-tempssd/'
+
+        commands.append('cd %s' % workdir)
+
+        commands.append(
+            ('python %s -P %i -A %s -t %s -a %s -r %s -f %s -cp '
+             '%s/chpoint-%s -o %s -d %s -p %s '
+             '1>>%s/sepp-%s-out.log 2>%s/sepp-%s-err.log') % (
+                ('%ssepp/run_sepp.py' % dir_base),  # python script of SEPP
+                5000,  # problem size for tree
+                1000,  # problem size for alignment
+                # reference tree file
+                ('%sref/reference-gg-raxml-bl-rooted-relabelled.tre' %
+                    dir_base),
+                # reference alignment file
+                ('%sref/gg_13_5_ssu_align_99_pfiltered.fasta' % dir_base),
+                # reference info file
+                ('%sref/RAxML_info-reference-gg-raxml-bl.info' % dir_base),
+                workdir + '/sequences.mfa',  # sequence input file
+                dir_tmp,  # tmpdir
+                name,
+                name,
+                workdir,
+                dir_tmp,
+                workdir,
+                name,
+                workdir,
+                name))
+
+        commands.append(('%s/sepp/tools/bundled/Linux/guppy-64 tog %s/%s_plac'
+                         'ement.json') % (dir_base, workdir, name))
+        commands.append(('python %s/%s_rename-json.py < %s/%s_placement.tog.t'
+                         're > %s/%s_placement.tog.relabelled.tre') %
+                        (workdir, name, workdir, name, workdir, name))
+        commands.append(('%s/sepp/tools/bundled/Linux/guppy-64 tog --xml %s/%'
+                         's_placement.json') % (dir_base, workdir, name))
+        commands.append(('python %s/%s_rename-json.py < %s/%s_placement.tog.x'
+                         'ml > %s/%s_placement.tog.relabelled.xml') %
+                        (workdir, name, workdir, name, workdir, name))
+
+        return commands
+
+    def post_execute(workdir, args):
+        file_merged_tree = workdir +\
+            '/seppstepbysteprun_placement.tog.relabelled.tre'
+        sys.stderr.write("step 1/2) reading skbio tree: ...")
+        tree = TreeNode.read(file_merged_tree, format='newick')
+        sys.stderr.write(' done.\n')
+
+        sys.stderr.write("step 2/2) use the phylogeny to det"
+                         "ermine tips lineage: ")
+        lineages = []
+        features = []
+        divisor = int(tree.count(tips=True) / min(10, tree.count(tips=True)))
+        for i, tip in enumerate(tree.tips()):
+            if i % divisor == 0:
+                sys.stderr.write('.')
+            if tip.name.isdigit():
+                continue
+
+            lineage = []
+            for ancestor in tip.ancestors():
+                try:
+                    float(ancestor.name)
+                except TypeError:
+                    pass
+                except ValueError:
+                    lineage.append(ancestor.name)
+
+            lineages.append("; ".join(reversed(lineage)))
+            features.append(tip.name)
+        sys.stderr.write(' done.\n')
+
+        # storing tree as newick string is necessary since large trees would
+        # result in too many recursions for the python heap :-/
+        newick = StringIO()
+        tree.write(newick)
+        return {'taxonomy': pd.DataFrame(data=lineages,
+                                         index=features,
+                                         columns=['taxonomy']),
+                'tree': newick.getvalue(),
+                'reference': args['reference']}
+
+    inp = sorted(counts.index)
+    if type(counts) == pd.Series:
+        # typically, the input is an OTU table with index holding sequences.
+        # However, if provided a Pandas.Series, we expect index are sequence
+        # headers and single column holds sequences.
+        inp = counts.sort_index()
+
+    seqs = inp
+    if type(inp) != pd.Series:
+        seqs = pd.Series(inp, index=inp).sort_index()
+    return _executor('seppstep',
+                     {'seqs': seqs,
+                      'reference': reference},
+                     pre_execute,
+                     commands,
+                     post_execute,
+                     ppn=ppn, pmem=pmem, walltime=walltime,
+                     **executor_args)
+
+
+def sepp_git(counts,
+             ppn=20, pmem='8GB', walltime='12:00:00',
+             **executor_args):
+    """Latest git version of SEPP.
+       Tip insertion of deblur sequences into GreenGenes backbone tree.
+
+    Parameters
+    ----------
+    counts : Pandas.DataFrame | Pandas.Series
+        a) OTU counts in form of a Pandas.DataFrame.
+        b) If providing a Pandas.Series, we expect the index to be a fasta
+           headers and the colum the fasta sequences.
+    executor_args:
+        dry, use_grid, nocache, wait, walltime, ppn, pmem, timing, verbose
+
+    Returns
+    -------
+    ???"""
+    def pre_execute(workdir, args):
+        file_fragments = workdir + '/sequences.mfa'
+        f = open(file_fragments, 'w')
+        for header, sequence in seqs.iter():
+            f.write('>%s\n%s\n' % (header, sequence))
+        f.close()
+        os.makedirs(workdir + '/sepp-tempssd/', exist_ok=True)
+
+    def commands(workdir, ppn, args):
+        commands = []
+        commands.append('cd %s' % workdir)
+        commands.append('%srun-sepp.sh "%s" res -x %i' % (
+            ('/home/sjanssen/Benchmark_insertiontree/'
+             'Software/sepp/sepp-package/'),
+            workdir+'/sequences.mfa',
+            ppn))
+        return commands
+
+    def post_execute(workdir, args):
+        file_merged_tree = workdir +\
+            '/res_placement.tog.relabelled.tre'
+        sys.stderr.write("step 1/2) reading skbio tree: ...")
+        tree = TreeNode.read(file_merged_tree, format='newick')
+        sys.stderr.write(' done.\n')
+
+        sys.stderr.write("step 2/2) use the phylogeny to det"
+                         "ermine tips lineage: ")
+        lineages = []
+        features = []
+        divisor = int(tree.count(tips=True) / min(10, tree.count(tips=True)))
+        for i, tip in enumerate(tree.tips()):
+            if i % divisor == 0:
+                sys.stderr.write('.')
+            if tip.name.isdigit():
+                continue
+
+            lineage = []
+            for ancestor in tip.ancestors():
+                try:
+                    float(ancestor.name)
+                except TypeError:
+                    pass
+                except ValueError:
+                    lineage.append(ancestor.name)
+
+            lineages.append("; ".join(reversed(lineage)))
+            features.append(tip.name)
+        sys.stderr.write(' done.\n')
+
+        # storing tree as newick string is necessary since large trees would
+        # result in too many recursions for the python heap :-/
+        newick = StringIO()
+        tree.write(newick)
+        return {'taxonomy': pd.DataFrame(data=lineages,
+                                         index=features,
+                                         columns=['taxonomy']),
+                'tree': newick.getvalue()}
+
+    inp = sorted(counts.index)
+    if type(counts) == pd.Series:
+        # typically, the input is an OTU table with index holding sequences.
+        # However, if provided a Pandas.Series, we expect index are sequence
+        # headers and single column holds sequences.
+        inp = counts.sort_index()
+
+    seqs = inp
+    if type(inp) != pd.Series:
+        seqs = pd.Series(inp, index=inp).sort_index()
+    return _executor('seppgit',
+                     {'seqs': seqs},
+                     pre_execute,
+                     commands,
+                     post_execute,
+                     environment='sepp_git',
+                     ppn=ppn, pmem=pmem, walltime=walltime,
+                     **executor_args)

--- a/ggmap/execute.py
+++ b/ggmap/execute.py
@@ -10,6 +10,7 @@ import subprocess
 from time import sleep, time
 from datetime import datetime
 from pickle import dump, load
+from shutil import rmtree
 
 import pandas as pd
 
@@ -898,7 +899,7 @@ def _executor(jobname, cache_arguments, pre_execute, commands, post_execute,
 
     if results['results'] is not None:
         if not dirty:
-            shutil.rmtree(results['workdir'])
+            rmtree(results['workdir'])
             if verbose:
                 verbose.write(" Was removed.\n")
 

--- a/ggmap/execute.py
+++ b/ggmap/execute.py
@@ -1,0 +1,910 @@
+# This file shall contain all code that is necessary to execute other software
+# either locally or via a SLURM grid. It contains mechanisms for caching, ...
+
+from sys import stderr, stdout
+import os
+from hashlib import md5, sha256
+from collections import OrderedDict
+from tempfile import gettempdir, mkdtemp
+import subprocess
+from time import sleep, time
+from datetime import datetime
+from pickle import dump, load
+
+import pandas as pd
+
+from skbio.stats.distance import DistanceMatrix
+from biom.table import Table
+
+from ggmap import settings
+settings.init()
+
+def cache(func):
+    """Decorator: Cache results of a function call to disk. It's the users
+       obligation to assign the cached data to the according function through
+       the choice of a filename for the cache. It does NOT depend on the
+       function arguments.
+
+    Parameters
+    ----------
+    func : executabale
+        A function plus parameters whichs results shall be cached, e.g.
+        "fct_example(1,5,3)", where
+        @cache
+        def fct_test(a, b, c):
+            return a + b * c
+    cache_filename : str
+        Default: None. I.e. caching is deactivated.
+        Pathname to cache file, which will hold results of the function call.
+        If file exists, results are loaded from it instead of recomputing via
+        provided function. Otherwise, function will be executed and results
+        stored to this file.
+    cache_verbose : bool
+        Default: True.
+        Report caching status to 'cache_err', which by default is sys.stderr.
+    cache_err : StringIO
+        Default: sys.stderr.
+        Stream onto which status messages shall be printed.
+    cache_force_renew : bool
+        Default: False.
+        Force re-execution of provided function even if cache file exists.
+
+    Returns
+    -------
+    Results of provided function, either by actually executing the function
+    with provided parameters or by loaded results from filename.
+
+    Notes
+    -----
+    It is the obligation of the user to ensure that arguments for the provided
+    function don't change between creation of cache file and loading from cache
+    file!
+    """
+    func_name = func.__name__
+
+    def execute(*args, **kwargs):
+        cache_args = {'cache_filename': None,
+                      'cache_verbose': True,
+                      'cache_err': stderr,
+                      'cache_force_renew': False}
+        for varname in cache_args.keys():
+            if varname in kwargs:
+                cache_args[varname] = kwargs[varname]
+                del kwargs[varname]
+
+        if cache_args['cache_filename'] is None:
+            if cache_args['cache_verbose']:
+                cache_args['cache_err'].write(
+                    '%s: no caching, since "cache_filename" is None.\n' %
+                    func_name)
+            return func(*args, **kwargs)
+
+        if os.path.exists(cache_args['cache_filename']) and\
+           (os.stat(cache_args['cache_filename']).st_size <= 0):
+            if cache_args['cache_verbose']:
+                cache_args['cache_err'].write(
+                    '%s: removed empty cache.\n' %
+                    func_name)
+            os.remove(cache_args['cache_filename'])
+
+        if (not os.path.exists(cache_args['cache_filename'])) or\
+           cache_args['cache_force_renew']:
+            try:
+                f = open(cache_args['cache_filename'], 'wb')
+                results = func(*args, **kwargs)
+                dump(results, f)
+                f.close()
+                if cache_args['cache_verbose']:
+                    cache_args['cache_err'].write(
+                        '%s: stored results in cache "%s".\n' %
+                        (func_name, cache_args['cache_filename']))
+            except Exception as e:
+                raise e
+        else:
+            f = open(cache_args['cache_filename'], 'rb')
+            results = load(f)
+            f.close()
+            if cache_args['cache_verbose']:
+                cache_args['cache_err'].write(
+                    '%s: retrieved results from cache "%s".\n' %
+                    (func_name, cache_args['cache_filename']))
+        return results
+    if func.__doc__ is not None:
+        execute.__doc__ = func.__doc__
+    else:
+        execute.__doc__ = ""
+    execute.__doc__ += "\n\n" + cache.__doc__
+    # restore wrapped function name
+    execute.__name__ = func_name
+    return execute
+
+
+def _time_torque2slurm(t_time):
+    """Convertes run-time resource string from Torque to Slurm.
+    Input format is hh:mm:ss, output is <days>-<hours>:<minutes>
+
+    Parameters
+    ----------
+    t_time : str
+        Input time duration in format hh:mm:ss
+
+    Returns
+    -------
+    Slurm compatible time duration.
+    """
+    t_hours, t_minutes, t_seconds = map(int, t_time.split(':'))
+    s_minutes = (t_seconds // 60) + t_minutes
+    s_hours = (s_minutes // 60) + t_hours
+    s_minutes = s_minutes % 60
+    s_days = s_hours // 24
+    s_hours = s_hours % 24
+
+    # set a minimal run time, if Torque time is < 60 seconds
+    if (s_days == 0) and (s_hours == 0) and (s_minutes == 0):
+        s_minutes = 1
+
+    return "%i-%02i:%02i:00" % (s_days, s_hours, s_minutes)
+
+
+def _add_timing_cmds(commands, file_timing):
+    """Change list of commands, such that system's time is used to trace
+       run-time.
+
+    Parameters
+    ----------
+    commands : [str]
+        List of commands.
+    file_timing : str
+        Filepath to the file into which timing information shall be written
+
+    Returns
+    -------
+    [str] list of changed commands with timing capability.
+    """
+    timing_cmds = []
+    # report machine name
+    timing_cmds.append('uname -a > %s' % file_timing)
+    # report commands to be executed (I have problems with quotes)
+    # timing_cmds.append('echo `%s` >> ${PBS_JOBNAME}.t${PBS_JOBID}'
+    #                    % '; '.join(cmds))
+    # add time to every command
+    for cmd in commands:
+        # cd cannot be timed and any attempt will fail changing the
+        # directory
+        if cmd.startswith('cd ') or\
+           cmd.startswith('module load ') or\
+           cmd.startswith('var_') or\
+           cmd.startswith('export ') or\
+           cmd.startswith('source ') or\
+           cmd.startswith('ulimit '):
+                timing_cmds.append(cmd)
+        elif cmd.startswith('if [ '):
+            ifcon, rest = re.findall(
+                r'(if \[.+?\];\s*then\s*)(.+)', cmd, re.IGNORECASE)[0]
+            timing_cmds.append(('%s '
+                                '%s '
+                                '-v '
+                                '-o %s '
+                                '-a %s') %
+                               (ifcon, settings.EXEC_TIME, file_timing, rest))
+        else:
+            timing_cmds.append(('%s '
+                                '-v '
+                                '-o %s '
+                                '-a %s') %
+                               (settings.EXEC_TIME, file_timing, cmd))
+    return timing_cmds
+
+
+def get_conda_activate_cmd(use_grid, environment):
+    if settings.GRIDNAME == 'JLU':
+        # but remember to to create the ~/.bash_profile file and copy and paste conda init script from .bashrc!
+        if use_grid is False:
+            cmd_conda = "source %s/etc/profile.d/conda.sh; conda activate %s; " % (settings.DIR_CONDA, environment)
+        else:
+            cmd_conda = "conda activate %s; " % (environment)
+    elif settings.GRIDNAME == 'JLU_SLURM':
+        cmd_conda = "source %s/etc/profile.d/conda.sh; conda activate %s; " % (settings.DIR_CONDA, environment)
+    else:
+        cmd_conda = "source %s/etc/profile.d/conda.sh; %s/condabin/conda activate %s; " % (
+            settings.DIR_CONDA, settings.DIR_CONDA, environment)
+    return cmd_conda
+
+
+def cluster_run(cmds, jobname, result, environment=None,
+                walltime='4:00:00', nodes=1, ppn=10, pmem='8GB',
+                gebin=settings.GRIDENGINE_BINDIR, dry=True, wait=False,
+                file_qid=None, file_condaenvinfo=None, out=stdout,
+                err=stderr, timing=False, file_timing=None, array=1,
+                use_grid=settings.USE_GRID,
+                force_slurm=False, no_mail=False):
+    """ Submits a job to the cluster.
+
+    Paramaters
+    ----------
+    cmds : [str]
+        List of commands to be run on the cluster.
+    jobname : str
+        A name for the cluster job.
+    result : path
+        A file or dir holding results of a sucessful run. Don't re-submit if
+        result exists.
+    environment : str
+        Name of a conda environment to activate.
+    walltime : str
+        Format hh:mm:ss maximal CPU time for the job. Default: '4:00:00'.
+    nodes : int
+        Number of nodes onto the job should be distributed. Defaul: 1
+    ppn : int
+        Number of cores within one node onto which the job should be
+        distributed. Default 10.
+    pmem : str
+        Format 'xGB'. Memory requirement per ppn for the job, e.g. if ppn=10
+        and pmem=8GB the node must have at least 80GB free memory.
+        Default: '8GB'.
+    gebin : path
+        Path to the dir holding SGE binaries.
+        Default: /opt/torque-4.2.8/bin
+    dry : bool
+        Only print command instead of executing it. Good for debugging.
+        Default = True
+    wait : bool
+        Wait for job completion before qsub's return
+    file_qid : str
+        Default None. Create a file containing the qid of the submitted job.
+        This will ease identification of TMP working directories.
+    file_condaenvinfo : str
+        Default: None.
+        If specified, AND environment is not None,
+        the result of "conda list --name X" is written to this file.
+    out : StringIO
+        Buffer onto which messages should be printed. Default is sys.stdout.
+    err : StringIO
+        Default: sys.stderr.
+        Buffer for status reports.
+    timing : bool
+        If True than add time output to every command and store in cr_*.t*
+        file. Default is False.
+    file_timing : str
+        Default: None
+        Define filepath into which timeing information shall be written.
+    array : int
+        Default: 1
+        If > 1 than an array job is submitted. Make sure in- and outputs can
+        deal with ${PBS_ARRAY_INDEX}!
+        Only available for Torque.
+    use_grid : bool
+        Defaul: True.
+        If False, commands are executed locally instead of submitting them to
+        a HPC (= either Torque or Slurm).
+    force_slurm : bool
+        Default: False.
+        If True, cluster_run is enforeced to choose slurm instead of auto
+        detection based on machine node name.
+    no_mail : bool
+        Default: False
+        If True, will not send emails about exit status when complete.
+
+    Returns
+    -------
+    Cluster job ID as str.
+    """
+    VALID_CMDS_KEYS = ['pre', 'main', 'post']
+
+    if result is None:
+        raise ValueError("You need to specify a result path.")
+    parent_res_dir = "/".join(result.split('/')[:-1])
+    if not os.access(parent_res_dir, os.W_OK):
+        raise ValueError("Parent result directory '%s' is not writable!" %
+                         parent_res_dir)
+    if file_qid is not None:
+        if not os.access('/'.join(file_qid.split('/')[:-1]), os.W_OK):
+            raise ValueError("Cannot write qid file '%s'." % file_qid)
+    if os.path.exists(result):
+        if err:
+            err.write("%s already computed\n" % jobname)
+        return "Result already present!"
+    if jobname is None:
+        raise ValueError("You need to set a jobname!")
+    if len(jobname) <= 1:
+        raise ValueError("You need to set non empty jobname!")
+
+    if isinstance(cmds, str):
+        cmds = [cmds]
+    # new mechanism: I want to enable job dependencies, i.e. some commands need
+    # to finish (e.g. prepare command input files) before an array job can
+    # highly parallel be executed e.g. rarefaction iterations.
+    # Therefore, I expect cmds to be a dictionary with keys 'pre' 'main' and
+    # 'post'
+    if isinstance(cmds, dict):
+        if set(cmds.keys() - set(VALID_CMDS_KEYS)) != set([]):
+            raise ValueError(
+                ("your command dictionary has unknown keys: '%s'. "
+                 "Please only use 'pre', 'main', and 'post'!") % "','".join(
+                    set(cmds.keys() - set(VALID_CMDS_KEYS))))
+    elif isinstance(cmds, list):
+        # no specific command category given, assume all commands shall be "main"
+        cmds = {'pre': [], 'main': cmds, 'post': []}
+    assert isinstance(cmds, dict)
+
+    for cmdtype in VALID_CMDS_KEYS:
+        for cmd in cmds[cmdtype]:
+            if "'" in cmd:
+                raise ValueError("One of your commands contain a ' char. "
+                                 "Please remove!")
+
+    fps_timing = {k: None for k in VALID_CMDS_KEYS}
+    if timing:
+        for cmdtype in VALID_CMDS_KEYS:
+            if file_timing is None:
+                fps_timing[cmdtype] = '%s.t${%s}.%s' % (jobname, settings.VARNAME_PBSARRAY, cmdtype)
+            else:
+                fps_timing[cmdtype] = '%s.%s' % (file_timing, cmdtype)
+            if cmdtype != 'main':
+                fps_timing[cmdtype] = fps_timing[cmdtype].replace('${%s}' % settings.VARNAME_PBSARRAY, '')
+            cmds[cmdtype] = _add_timing_cmds(cmds[cmdtype], fps_timing[cmdtype])
+
+    cmd_list = {k: "" for k in VALID_CMDS_KEYS}
+    cmd_conda = ""
+    env_present = None
+    fps_scripts = dict()
+    if environment is not None:
+        if file_condaenvinfo is None:
+            file_condaenvinfo = ""
+        else:
+            file_condaenvinfo = " > %s" % file_condaenvinfo
+        # check if environment exists
+        if '/' not in environment:  # special case where we use environments in non standard paths
+            with subprocess.Popen("%s/condabin/conda list -n %s %s" % (settings.DIR_CONDA, environment, file_condaenvinfo),
+                                  shell=True,
+                                  stdout=subprocess.PIPE) as env_present:
+                if (env_present.wait() != 0):
+                    raise ValueError("Conda environment '%s' not present." %
+                                     environment)
+        cmd_conda = get_conda_activate_cmd(use_grid, environment)
+        # if settings.GRIDNAME == 'JLU':
+        #     # but remember to to create the ~/.bash_profile file and copy and paste conda init script from .bashrc!
+        #     if use_grid is False:
+        #         cmd_conda = "source %s/etc/profile.d/conda.sh; conda activate %s; " % (settings.DIR_CONDA, environment)
+        #     else:
+        #         cmd_conda = "conda activate %s; " % (environment)
+        # elif settings.GRIDNAME == 'JLU_SLURM':
+        #     cmd_conda = "source %s/etc/profile.d/conda.sh; conda activate %s; " % (settings.DIR_CONDA, environment)
+        # else:
+        #     cmd_conda = "source %s/etc/profile.d/conda.sh; %s/condabin/conda activate %s; " % (
+        #         settings.DIR_CONDA, settings.DIR_CONDA, environment)
+
+    slurm = False
+    if use_grid is False:
+        cmd_list['SPAWN'] = cmd_conda
+        cmd_list['SPAWN'] += " && ".join(cmds['pre'])
+        if len(cmds['pre']) > 0:
+            cmd_list['SPAWN'] += ' && '
+        cmd_list['SPAWN'] += ' for %s in `seq 1 %i`; do %s; done;' % (
+            settings.VARNAME_PBSARRAY, array, " && ".join(cmds['main']))
+        cmd_list['SPAWN'] += ' %s' % " && ".join(cmds['post'])
+    else:
+        pwd = subprocess.check_output(["pwd"]).decode('ascii').rstrip()
+
+        if (settings.GRIDNAME == 'USF') or (settings.PREFER_SLURM):
+            slurm = True
+        else:
+            slurm = False
+        with subprocess.Popen("which srun" if slurm else "which qsub",
+                              shell=True, stdout=subprocess.PIPE,
+                              executable="bash") as call_x:
+            if call_x.wait() != 0:
+                msg = ("You don't seem to have access to a grid!")
+                if dry:
+                    if err is not None:
+                        err.write(msg)
+                else:
+                    raise ValueError(msg)
+        if force_slurm:
+            slurm = True
+
+        if slurm is False:
+            highmem = ''
+            if settings.GRIDNAME == 'barnacle':
+                if ppn * int(pmem[:-2]) > 250:
+                    highmem = ':highmem'
+            files_loc = ''
+            if file_qid is not None:
+                files_loc = ' -o %s/ -e %s/ ' % tuple(
+                    ["/".join(file_qid.split('/')[:-1])] * 2)
+
+            flag_array = ''
+            if array > 1:
+                if settings.GRIDNAME == 'barnacle' or settings.GRIDNAME == 'JLU':
+                    flag_array = '-t 1-%i' % array
+                elif settings.GRIDNAME == 'HPCHHU':
+                    flag_array = '-J 1-%i' % array
+            resources = " -l walltime=%s,nodes=%i%s:ppn=%i,mem=%s " % (
+                walltime, nodes, highmem, ppn, pmem)
+            if settings.GRIDNAME == 'JLU':
+                # further differentiate between old and new 18.04 cluster (08.04.2020)
+                arg_multislot = " -pe multislot %i " % ppn
+                #if settings.GRIDENGINE_BINDIR == '/usr/bin/':
+                    # according to Burkhard, the "new cluster" doesn't have multislots yet
+                    # UPDATE: 2021-01-06: "das PE ist da, sollte auch funktionieren"
+                #    arg_multislot = ""
+                pmem_value = pmem
+                if pmem is None:
+                    pmem_value = '8GB'
+                else:
+                    pmem_value = pmem[:-1] if pmem.upper().endswith('B') else pmem
+                resources = " -l virtual_free=%s %s -S /bin/bash " % (pmem_value, arg_multislot)
+            ge_cmd = (
+                ("%s/qsub %s %s -V %s -N cr_%s %s %s -r y") %
+                (gebin,
+                 '-A %s' % settings.GRID_ACCOUNT if settings.GRID_ACCOUNT != "" else "",
+                 "-d '%s'" % pwd if settings.GRIDNAME == 'barnqacle' else '',
+                 resources,
+                 jobname, flag_array, files_loc))
+            cmd_list['main'] += "echo '%s%s' | %s" % (cmd_conda, " && ".join(cmds), ge_cmd)
+        else:
+            for cmdtype in VALID_CMDS_KEYS:
+                slurm_script = "#!/bin/bash\n\n"
+                slurm_script += '#SBATCH --job-name=cr_%s_%s\n' % (jobname, cmdtype)
+                slurm_script += '#SBATCH --output=%s/slurmlog-%%x-%%A.%%a_%s.log\n' % (pwd if file_qid is None else os.path.abspath(os.path.dirname(file_qid)), cmdtype)
+                slurm_script += '#SBATCH --error=%s/slurmlog-%%x-%%A.%%a_%s.err\n' % (pwd if file_qid is None else os.path.abspath(os.path.dirname(file_qid)), cmdtype)
+                slurm_script += '#SBATCH --partition=%s\n' % settings.GRID_ACCOUNT
+                slurm_script += '#SBATCH --ntasks=1\n'
+                slurm_script += '#SBATCH --cpus-per-task=%i\n' % ppn
+                slurm_script += '#SBATCH --mem-per-cpu=%s\n' % (pmem.upper() if pmem is not None else '8GB')
+                slurm_script += '#SBATCH --time=%s\n' % _time_torque2slurm(
+                    walltime)
+                if cmdtype == 'main':
+                    slurm_script += '#SBATCH --array=1-%i\n' % array
+                if cmdtype == 'post' and (no_mail is False):
+                    slurm_script += '#SBATCH --mail-type=END,FAIL\n'
+                    slurm_script += '#SBATCH --mail-user=%s\n\n' % settings.GRID_EMAIL_NOTIFICATION
+                slurm_script += '$(which uname) -a\n'
+
+                for cmd in cmds[cmdtype]:
+                    if cmdtype != 'main':
+                        assert settings.VARNAME_PBSARRAY not in cmd, "array job can only be used in 'main'"
+                    slurm_script += '%s\n' % (cmd.replace(
+                        '${%s}' % settings.VARNAME_PBSARRAY, '${SLURM_ARRAY_TASK_ID}'))
+                if file_qid is not None:
+                    file_script = os.path.dirname(file_qid) + '/slurm_script_%s.sh' % cmdtype
+                else:
+                    _, file_script = mkstemp(suffix='.slurm.sh')
+                fps_scripts[cmdtype] = file_script
+                f = open(fps_scripts[cmdtype], 'w')
+                f.write(slurm_script)
+                f.close()
+            # if on jupyterlab from BCF@JLU, some slurm vars are predefined for the
+            # spawner process of the jupyterlab. We need to unset this specific
+            # variable to avoid slurm complaining about other resource requests.
+            if settings.GRIDNAME == 'JLU_SLURM':
+                cmd_list['SPAWN'] = 'unset SLURM_MEM_PER_NODE && '
+            cmd_list['SPAWN'] += cmd_conda
+            cmd_list['SPAWN'] += ' qid_pre=`%ssbatch --parsable %s`' % (settings.GRIDENGINE_BINDIR, fps_scripts['pre'])
+            cmd_list['SPAWN'] += ' && qid_main=`%ssbatch --parsable --dependency=aftercorr:$qid_pre %s`' % (settings.GRIDENGINE_BINDIR, fps_scripts['main'])
+            cmd_list['SPAWN'] += ' && %ssbatch --parsable --depend=afterany:$qid_main %s' % (settings.GRIDENGINE_BINDIR, fps_scripts['post'])
+
+    if dry is True:
+        if use_grid and slurm:
+            for cmdtype in VALID_CMDS_KEYS:
+                out.write('CONTENT OF %s:\n' % fps_scripts[cmdtype])
+                with open(fps_scripts[cmdtype], 'r') as f:
+                    out.write(''.join(f.readlines()) + "\n\n")
+        out.write(cmd_list['SPAWN'] + "\n")
+        return None
+    else:
+        if use_grid is True:
+            with subprocess.Popen(
+                    cmd_list['SPAWN'], shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, executable='/bin/bash') as task_qsub:
+                err_msg = task_qsub.stderr.read()
+                if err_msg != b"":
+                    raise ValueError("Error in submitting job via qsub:\n%s" % err_msg.decode('ascii'))
+                qid = task_qsub.stdout.read().decode('ascii').rstrip()
+                #if settings.GRIDNAME == 'JLU':
+                #    qid = qid.split(" ")[2]
+                if slurm:
+                    qid = qid.split()[-1]
+                    if file_qid is not None:
+                        os.remove(file_script)
+                if file_qid is not None:
+                    f = open(file_qid, 'w')
+                    f.write('Cluster job ID is:\n%s\n' % qid)
+                    f.close()
+                job_ever_seen = False
+                if wait:
+                    err.write(
+                        "\nWaiting for %s-cluster job %s to complete: " % ('slurm' if slurm else 'sge', qid))
+                    while True:
+                        if slurm:
+                            with subprocess.Popen(
+                                    ['squeue', '--job', qid],
+                                    stdout=subprocess.PIPE) as task_squeue:
+                                with subprocess.Popen(
+                                        ['wc', '-l'], stdin=task_squeue.stdout,
+                                        stdout=subprocess.PIPE) as task_wc:
+                                    poll_status = \
+                                        int(task_wc.stdout.read().decode(
+                                            'ascii').rstrip())
+                            # Two ore more if polling gives a table with header
+                            # and one status line, i.e. job is still on the
+                            # grid. Translate that to 0 of Torque.
+                            # If table has only one line, i.e. the header, job
+                            # terminated (hopefully successful), translate that
+                            # to 1 of Torque
+                            if poll_status >= 2:
+                                poll_status = 0
+                            else:
+                                poll_status = 1
+                        else:
+                            poll_stati = []
+                            for i in range(array):
+                                p = subprocess.call(
+                                    "%s/qstat %s %s" %
+                                    (gebin,
+                                     ' -j ' if settings.GRIDNAME == 'JLU' else '',
+                                     qid.replace('[]', '[%i]' % (i+1))),
+                                    shell=True)
+                                poll_stati.append(p == 0)
+                            if any(poll_stati):
+                                poll_status = 0
+                            else:
+                                poll_status = 127  # some number != 0
+                        if (poll_status != 0) and job_ever_seen:
+                            err.write(' finished.')
+                            break
+                        elif (poll_status == 0) and (not job_ever_seen):
+                            job_ever_seen = True
+                        err.write('.')
+                        sleep(10)
+                else:
+                    err.write("Now wait until %s job finishes.\n" % qid)
+                return qid
+        else:
+            #if settings.GRIDNAME == 'JLU':
+            #    cmd_list = 'source ~/.profile && ' + cmd_list
+            with subprocess.Popen(cmd_list['SPAWN'],
+                                  shell=True,
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.PIPE,
+                                  executable="bash") as call_x:
+                if (call_x.wait() != 0):
+                    out, err = call_x.communicate()
+                    raise ValueError((
+                        "SYSTEM CALL FAILED.\n==== STDERR ====\n%s"
+                        "\n\n==== STDOUT ====\n%s\n") % (
+                            err.decode("utf-8", 'backslashreplace'),
+                            out.decode("utf-8", 'backslashreplace')))
+                return call_x.pid
+
+
+def _parse_timing(workdir, jobname):
+    """If existant, parses timing information.
+
+    Parameters
+    ----------
+    workdir : str
+        Path to tmp workdir of _executor containing cr_ana_<jobname>.t* file
+    jobname : str
+        Name of ran job.
+
+    Parameters
+    ----------
+    None if file could not be found. Otherwise: [str]
+    """
+    files_timing = [workdir + '/' + d
+                    for d in next(os.walk(workdir))[2]
+                    if 'cr_ana_%s.t' % jobname in d]
+    for file_timing in files_timing:
+        with open(file_timing, 'r') as content_file:
+            return content_file.readlines()
+        # stop after reading first found file, since there should only be one
+        break
+    return None
+
+
+def _md5(filepath):
+    """Returns md5sum of file path"""
+    hash_md5 = md5()
+    with open(filepath, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash_md5.update(chunk)
+    return hash_md5.hexdigest()
+
+
+def pandas_hash(df):
+    # sort indices (only one for Series)
+    df_cache = df.sort_index()
+    if isinstance(df, pd.DataFrame):
+        df_cache = df_cache.sort_index(axis=1)
+
+    # generate one hash per row with pandas own lib
+    row_hashes = pd.util.hash_pandas_object(df_cache, index=True)
+
+    # combine all row-hashes into one
+    return sha256(row_hashes.values.tobytes()).hexdigest()
+
+
+def _executor(jobname, cache_arguments, pre_execute, commands, post_execute,
+              post_cache=None, post_cache_arguments=dict(),
+              dry=True, use_grid=True, ppn=10, nocache=False,
+              pmem='20GB', environment=settings.QIIME_ENV, walltime='4:00:00',
+              wait=True, timing=True, verbose=stderr, array=1,
+              dirty=False, load_cachefile=None):
+    """
+
+    Parameters
+    ----------
+    jobname : str
+    cache_arguments : []
+    pre_execute : function
+    commands : [] or dict:{'pre': [], 'main': [], 'post': []}
+    post_execute : function
+    post_cache : function
+        A function that is called, after results have been loaded from cache /
+        were generated. E.g. drawing rarefaction curves.
+    environment : str
+
+    ==template arguments that should be copied to calling analysis function==
+    dry : bool
+        Default: True.
+        If True: only prepare working directory and create necessary input
+        files and print the command that would be executed in a non dry run.
+        For debugging. Workdir is not deleted.
+        "pre_execute" is called, but not "post_execute".
+    use_grid : bool
+        Default: True.
+        If True, use qsub to schedule as a grid job, otherwise run locally.
+    nocache : bool
+        Default: False.
+        Normally, successful results are cached in .anacache directory to be
+        retrieved when called a second time. You can deactivate this feature
+        (useful for testing) by setting "nocache" to True.
+    wait : bool
+        Default: True.
+        Wait for results.
+    walltime : str
+        Default: "12:00:00".
+        hh:mm:ss formated wall runtime on cluster.
+    ppn : int
+        Default: 10.
+        Number of CPU cores to be used.
+    pmem : str
+        Default: '8GB'.
+        Resource request for cluster jobs. Multiply by ppn!
+    timing : bool
+        Default: True
+        Use '/usr/bin/time' to log run time of commands.
+    verbose : stream
+        Default: sys.stderr
+        To silence this function, set verbose=None.
+    array : int
+        Default: 1 = deactivated.
+        Only for Torque submits: make the job an array job.
+        You need to take care of correct use of ${PBS_JOBID} !
+    dirty : bool
+        Defaul: False.
+        If True, temporary working directory will not be removed.
+    load_cachefile : str
+        Default: None
+        Provide a filepath to an existing cache file and the function will
+        load data from there - even if cache file is for a different type of
+        analysis!
+
+    Returns
+    -------
+    """
+    DIR_CACHE = '.anacache'
+    FILE_STATUS = 'finished.info'
+    results = {'results': None,
+               'workdir': None,
+               'qid': None,
+               'file_cache': None,
+               'cached_inputs': dict(),
+               'timing': None,
+               'cache_version': 20260622,
+               'created_on': None,
+               'conda_env': 'unknown',
+               'jobname': jobname}
+
+    # create an ID function if no post_cache function is supplied
+    def _id(x):
+        return x
+    if post_cache is None:
+        post_cache = _id
+
+    if load_cachefile is not None:
+        # a short cut to load a specific cache file, ignoring all the remaining
+        # mechanisms!!
+        if verbose:
+            verbose.write("Loading existing results from '%s'. \n" %
+                          load_cachefile)
+        f = open(load_cachefile, 'rb')
+        results = load(f)
+        f.close()
+        if results['jobname'] != jobname:
+            verbose.write("!!Warning: loaded cache is for analysis '%s', but you are using it as '%s'!!" % (results['jobname'], jobname))
+        return post_cache(results, **post_cache_arguments)
+
+
+    # phase 1: compute signature for cache file
+    # convert skbio.DistanceMatrix object to a sorted version of its data for
+    # hashing
+    cache_args_original = dict()
+    for arg in cache_arguments.keys():
+        if type(cache_arguments[arg]) == DistanceMatrix:
+            cache_args_original[arg] = cache_arguments[arg]
+            dm = cache_arguments[arg]
+            cache_arguments[arg] = dm.filter(sorted(dm.ids)).data
+        if (type(cache_arguments[arg]) == dict):
+            if (len({type(v) for v in cache_arguments[arg].values()} ^
+                    set([DistanceMatrix])) == 0):
+                cache_args_original[arg] = cache_arguments[arg]
+                cache_arguments[arg] = OrderedDict(
+                    {k: dm.filter(sorted(dm.ids)).data
+                     for k, dm
+                     in cache_arguments[arg].items()})
+        if (type(cache_arguments[arg]) == pd.Series) or (type(cache_arguments[arg]) == pd.DataFrame):
+            cache_args_original[arg] = cache_arguments[arg]
+            cache_arguments[arg] = pandas_hash(cache_arguments[arg])
+        if isinstance(cache_arguments[arg], Table):
+            cache_args_original[arg] = cache_arguments[arg]
+            cache_arguments[arg] = sorted(list(cache_arguments[arg].ids('sample'))) + \
+                                   sorted(list(cache_arguments[arg].ids('observation'))) + \
+                                   [cache_arguments[arg].get_table_density()]
+        if (type(cache_arguments[arg]) == str) and os.path.exists(cache_arguments[arg]):
+            cache_args_original[arg] = cache_arguments[arg]
+            if os.path.isfile(cache_arguments[arg]):
+                # if argument can be used as a file path and the file actually exists...
+                # ... than use the md5sum of the file instead of the filepath for cache fingerprint
+                # Thus, moving the file will not affect the cache fingerprint
+                cache_arguments[arg] = _md5(cache_arguments[arg])
+            else:
+                # assume path is directory
+                cache_arguments[arg] = os.path.abspath(cache_arguments[arg])
+
+        # for better debugging, write hash sum for each input argument in result object
+        if cache_arguments[arg] is None:
+            results['cached_inputs'][arg] = None
+        else:
+            results['cached_inputs'][arg] = md5(str(cache_arguments[arg]).encode()).hexdigest()
+
+    _input = OrderedDict(sorted(cache_arguments.items()))
+    results['file_cache'] = "%s/%s.%s" % (DIR_CACHE, md5(
+        str(_input).encode()).hexdigest(), jobname)
+
+    # convert back cache arguments if necessary
+    for arg in cache_args_original.keys():
+        cache_arguments[arg] = cache_args_original[arg]
+
+    # phase 2: if cache contains matching file, load from cache and return
+    if os.path.exists(results['file_cache']) and (nocache is not True):
+        if verbose:
+            verbose.write("Using existing results from '%s'. \n" %
+                          results['file_cache'])
+        f = open(results['file_cache'], 'rb')
+        results = load(f)
+        f.close()
+        return post_cache(results, **post_cache_arguments)
+
+    # phase 3: search in TMP dir if non-collected results are
+    # ready or are waited for
+    dir_tmp = gettempdir()
+    if use_grid:
+        dir_tmp = os.environ['HOME'] + '/TMP/'
+        if not os.path.exists(dir_tmp):
+            raise ValueError('Temporary directory "%s" does not exist. '
+                             'Please create it and restart.' % dir_tmp)
+
+    # collect all tmp workdirs that contain the right cache signature
+    pot_workdirs = []
+    for _dir in next(os.walk(dir_tmp))[1]:
+        # a potential working directory needs to have the matching job name
+        if _dir.startswith('ana_%s_' % results['jobname']):
+            # for shared computers, make sure you have permission to read dir contents
+            if not os.access(os.path.join(dir_tmp, _dir), os.R_OK):
+                continue
+            potwd = os.path.join(dir_tmp, _dir)
+            # and a matching cache file signature
+            if results['file_cache'].split('/')[-1] in next(os.walk(potwd))[2]:
+                pot_workdirs.append(potwd)
+    finished_workdirs = []
+    for wd in pot_workdirs:
+        all_finished = os.path.exists('%s/finished.info' % wd)
+        # for i in range(array):
+        #     exp_finish_suffix = ""
+        #     if array > 1:
+        #         exp_finish_suffix = str(int(i+1))
+        #     if (array == 1):
+        #         if (settings.GRIDNAME == 'JLU'):
+        #             if use_grid:
+        #                 exp_finish_suffix = 'undefined'
+        #             else:
+        #                 exp_finish_suffix = '1'
+        #         else:
+        #             exp_finish_suffix = '1'
+        #     if not os.path.exists('%s/finished.info%s' % (wd, exp_finish_suffix)):
+        #         all_finished = False
+        #         break
+        if all_finished:
+            finished_workdirs.append(wd)
+    if len(pot_workdirs) > 0 and len(finished_workdirs) <= 0:
+        if verbose:
+            verbose.write(
+                ('Found %i temporary working directories, but non of '
+                 'them have finished (missing "finished.info" file). If no job is currently running,'
+                 ' you might want to delete these directories and res'
+                 'tart:\n  %s\n') % (len(pot_workdirs),
+                                     "\n  ".join(pot_workdirs)))
+        return results
+
+    if len(finished_workdirs) > 0:
+        # arbitrarily pick first found workdir
+        results['workdir'] = finished_workdirs[0]
+        if verbose:
+            verbose.write('found matching working dir "%s"\n' %
+                          results['workdir'])
+    else:
+        # create a temporary working directory
+        prefix = 'ana_%s_' % jobname
+        results['workdir'] = mkdtemp(prefix=prefix, dir=dir_tmp)
+        if verbose:
+            verbose.write("Working directory is '%s', cachefile is '%s'. " %
+                          (results['workdir'], results['file_cache']))
+        # leave an empty file in workdir with cache file name to later
+        # parse results from tmp dir
+        f = open("%s/%s" % (results['workdir'],
+                            results['file_cache'].split('/')[-1]), 'w')
+        f.close()
+
+        pre_execute(results['workdir'], cache_arguments)
+
+        lst_commands = commands(results['workdir'], ppn, cache_arguments)
+        # convert to new dict structure instead of flat list
+        if isinstance(lst_commands, list):
+            lst_commands = {'main': lst_commands, 'pre': [], 'post': []}
+        # device creation of a file _after_ execution of the job in workdir
+        final_cmd = 'touch %s/%s' % (results['workdir'], FILE_STATUS)
+        lst_commands['post'].append(final_cmd)
+
+        results['qid'] = cluster_run(
+            lst_commands, 'ana_%s' % jobname, results['workdir']+'mock',
+            environment, ppn=ppn, wait=wait, dry=dry,
+            pmem=pmem, walltime=walltime,
+            file_qid=results['workdir']+'/cluster_job_id.txt',
+            file_condaenvinfo=results['workdir']+'/conda_info.txt',
+            timing=timing,
+            file_timing=results['workdir']+('/timing${%s}.txt' % settings.VARNAME_PBSARRAY),
+            array=array, use_grid=use_grid)
+        if dry:
+            return results
+        if wait is False:
+            return results
+
+    results['results'] = post_execute(results['workdir'],
+                                      cache_arguments)
+    results['created_on'] = datetime.fromtimestamp(
+        time()).strftime('%Y-%m-%d %H:%M:%S')
+
+    results['conda_env'] = environment
+    if environment is not None:
+        with open(results['workdir']+'/conda_info.txt', 'r') as f:
+            results['conda_list'] = f.readlines()
+
+    results['timing'] = []
+    for timingfile in next(os.walk(results['workdir']))[2]:
+        if timingfile.startswith('timing'):
+            with open(results['workdir']+'/'+timingfile, 'r') as content_file:
+                results['timing'] += content_file.readlines()
+
+    if results['results'] is not None:
+        if not dirty:
+            shutil.rmtree(results['workdir'])
+            if verbose:
+                verbose.write(" Was removed.\n")
+
+    os.makedirs(os.path.dirname(results['file_cache']), exist_ok=True)
+    f = open(results['file_cache'], 'wb')
+    dump(results, f)
+    f.close()
+
+    return post_cache(results, **post_cache_arguments)

--- a/ggmap/execute.py
+++ b/ggmap/execute.py
@@ -11,6 +11,7 @@ from time import sleep, time
 from datetime import datetime
 from pickle import dump, load
 from shutil import rmtree
+from re import findall, IGNORECASE
 
 import pandas as pd
 
@@ -180,8 +181,8 @@ def _add_timing_cmds(commands, file_timing):
            cmd.startswith('ulimit '):
                 timing_cmds.append(cmd)
         elif cmd.startswith('if [ '):
-            ifcon, rest = re.findall(
-                r'(if \[.+?\];\s*then\s*)(.+)', cmd, re.IGNORECASE)[0]
+            ifcon, rest = findall(
+                r'(if \[.+?\];\s*then\s*)(.+)', cmd, IGNORECASE)[0]
             timing_cmds.append(('%s '
                                 '%s '
                                 '-v '
@@ -625,6 +626,64 @@ def pandas_hash(df):
     return sha256(row_hashes.values.tobytes()).hexdigest()
 
 
+def get_cache_filename(cache_arguments, jobname):
+    """Given arguments on which cache shall depend, create checksum"""
+    DIR_CACHE = '.anacache'
+
+    cached_inputs = dict()
+
+    cache_args_original = dict()
+    for arg in cache_arguments.keys():
+        if type(cache_arguments[arg]) == DistanceMatrix:
+            cache_args_original[arg] = cache_arguments[arg]
+            dm = cache_arguments[arg]
+            cache_arguments[arg] = dm.filter(sorted(dm.ids)).data
+        if (type(cache_arguments[arg]) == dict):
+            if (len({type(v) for v in cache_arguments[arg].values()} ^
+                    set([DistanceMatrix])) == 0):
+                cache_args_original[arg] = cache_arguments[arg]
+                cache_arguments[arg] = OrderedDict(
+                    {k: dm.filter(sorted(dm.ids)).data
+                     for k, dm
+                     in cache_arguments[arg].items()})
+        if (type(cache_arguments[arg]) == pd.Series) or (type(cache_arguments[arg]) == pd.DataFrame):
+            cache_args_original[arg] = cache_arguments[arg]
+            cache_arguments[arg] = pandas_hash(cache_arguments[arg])
+        if isinstance(cache_arguments[arg], Table):
+            cache_args_original[arg] = cache_arguments[arg]
+            cache_arguments[arg] = sorted(list(cache_arguments[arg].ids('sample'))) + \
+                                   sorted(list(cache_arguments[arg].ids('observation'))) + \
+                                   [cache_arguments[arg].get_table_density()]
+        if (type(cache_arguments[arg]) == str) and os.path.exists(cache_arguments[arg]):
+            cache_args_original[arg] = cache_arguments[arg]
+            if os.path.isfile(cache_arguments[arg]):
+                # if argument can be used as a file path and the file actually exists...
+                # ... than use the md5sum of the file instead of the filepath for cache fingerprint
+                # Thus, moving the file will not affect the cache fingerprint
+                cache_arguments[arg] = _md5(cache_arguments[arg])
+            else:
+                # assume path is directory
+                cache_arguments[arg] = os.path.abspath(cache_arguments[arg])
+
+        # for better debugging, write hash sum for each input argument in result object
+        if cache_arguments[arg] is None:
+            cached_inputs[arg] = None
+        else:
+            cached_inputs[arg] = md5(str(cache_arguments[arg]).encode()).hexdigest()
+
+    _input = OrderedDict({
+        k:v
+        for k,v
+        in sorted(cache_arguments.items())
+    })
+    fp_cache = "%s/%s.%s" % (DIR_CACHE, md5(
+        str(_input).encode()).hexdigest(), jobname)
+
+    return {'file_cache': fp_cache,
+            'cached_inputs': cache_arguments,
+            'cache_args_original': cache_args_original}
+
+
 def _executor(jobname, cache_arguments, pre_execute, commands, post_execute,
               post_cache=None, post_cache_arguments=dict(),
               dry=True, use_grid=True, ppn=10, nocache=False,
@@ -694,7 +753,6 @@ def _executor(jobname, cache_arguments, pre_execute, commands, post_execute,
     Returns
     -------
     """
-    DIR_CACHE = '.anacache'
     FILE_STATUS = 'finished.info'
     results = {'results': None,
                'workdir': None,
@@ -728,50 +786,10 @@ def _executor(jobname, cache_arguments, pre_execute, commands, post_execute,
 
 
     # phase 1: compute signature for cache file
-    # convert skbio.DistanceMatrix object to a sorted version of its data for
-    # hashing
-    cache_args_original = dict()
-    for arg in cache_arguments.keys():
-        if type(cache_arguments[arg]) == DistanceMatrix:
-            cache_args_original[arg] = cache_arguments[arg]
-            dm = cache_arguments[arg]
-            cache_arguments[arg] = dm.filter(sorted(dm.ids)).data
-        if (type(cache_arguments[arg]) == dict):
-            if (len({type(v) for v in cache_arguments[arg].values()} ^
-                    set([DistanceMatrix])) == 0):
-                cache_args_original[arg] = cache_arguments[arg]
-                cache_arguments[arg] = OrderedDict(
-                    {k: dm.filter(sorted(dm.ids)).data
-                     for k, dm
-                     in cache_arguments[arg].items()})
-        if (type(cache_arguments[arg]) == pd.Series) or (type(cache_arguments[arg]) == pd.DataFrame):
-            cache_args_original[arg] = cache_arguments[arg]
-            cache_arguments[arg] = pandas_hash(cache_arguments[arg])
-        if isinstance(cache_arguments[arg], Table):
-            cache_args_original[arg] = cache_arguments[arg]
-            cache_arguments[arg] = sorted(list(cache_arguments[arg].ids('sample'))) + \
-                                   sorted(list(cache_arguments[arg].ids('observation'))) + \
-                                   [cache_arguments[arg].get_table_density()]
-        if (type(cache_arguments[arg]) == str) and os.path.exists(cache_arguments[arg]):
-            cache_args_original[arg] = cache_arguments[arg]
-            if os.path.isfile(cache_arguments[arg]):
-                # if argument can be used as a file path and the file actually exists...
-                # ... than use the md5sum of the file instead of the filepath for cache fingerprint
-                # Thus, moving the file will not affect the cache fingerprint
-                cache_arguments[arg] = _md5(cache_arguments[arg])
-            else:
-                # assume path is directory
-                cache_arguments[arg] = os.path.abspath(cache_arguments[arg])
-
-        # for better debugging, write hash sum for each input argument in result object
-        if cache_arguments[arg] is None:
-            results['cached_inputs'][arg] = None
-        else:
-            results['cached_inputs'][arg] = md5(str(cache_arguments[arg]).encode()).hexdigest()
-
-    _input = OrderedDict(sorted(cache_arguments.items()))
-    results['file_cache'] = "%s/%s.%s" % (DIR_CACHE, md5(
-        str(_input).encode()).hexdigest(), jobname)
+    cache = get_cache_filename(cache_arguments, jobname)
+    results['file_cache'] = cache['file_cache']
+    results['cached_inputs'] = cache['cached_inputs']
+    cache_args_original = cache['cache_args_original']
 
     # convert back cache arguments if necessary
     for arg in cache_args_original.keys():

--- a/ggmap/settings.py
+++ b/ggmap/settings.py
@@ -69,6 +69,17 @@ DEFAULTS = {'condaenv_qiime1': {'default': 'qiime_env',
             }
 
 
+# a pretty version of metrics names
+NICE_METRICS = {
+    'shannon': 'Shannon',
+    'observed_features': 'number observed ASVs',
+    'PD_whole_tree': 'Faith\'s PD',
+
+    'bray_curtis': 'Bray-Curtis',
+    'unweighted_unifrac': 'unweighted UniFrac',
+    'weighted_unifrac': 'weighted UniFrac'}
+
+
 # stolen from https://stackoverflow.com/questions/13034496/
 # using-global-variables-between-files
 def init(err=sys.stderr, force_commit_msg=False):

--- a/ggmap/snippets.py
+++ b/ggmap/snippets.py
@@ -47,7 +47,7 @@ from skbio.sequence import DNA
 from skbio.tree import TreeNode
 
 from ggmap import settings
-
+from ggmap.execute import cache
 
 if 'PROJ_LIB' not in os.environ:
     os.environ['PROJ_LIB'] = os.path.join(*([os.path.sep] + sys.executable.split(os.path.sep)[:-2] + ['share', 'proj']))
@@ -56,14 +56,6 @@ from mpl_toolkits.basemap import Basemap
 settings.init()
 plt.rcParams['svg.fonttype'] = 'none'
 
-NICE_METRICS = {
-    'shannon': 'Shannon',
-    'observed_features': 'number observed ASVs',
-    'PD_whole_tree': 'Faith\'s PD',
-
-    'bray_curtis': 'Bray-Curtis',
-    'unweighted_unifrac': 'unweighted UniFrac',
-    'weighted_unifrac': 'weighted UniFrac'}
 
 def biom2pandas(file_biom, withTaxonomy=False, astype=int):
     """ Converts a biom file into a Pandas.DataFrame
@@ -1121,463 +1113,6 @@ def plotTaxonomy(file_otutable,
     return fig, rank_counts, graphinfo, vals, colors
 
 
-def _time_torque2slurm(t_time):
-    """Convertes run-time resource string from Torque to Slurm.
-    Input format is hh:mm:ss, output is <days>-<hours>:<minutes>
-
-    Parameters
-    ----------
-    t_time : str
-        Input time duration in format hh:mm:ss
-
-    Returns
-    -------
-    Slurm compatible time duration.
-    """
-    t_hours, t_minutes, t_seconds = map(int, t_time.split(':'))
-    s_minutes = (t_seconds // 60) + t_minutes
-    s_hours = (s_minutes // 60) + t_hours
-    s_minutes = s_minutes % 60
-    s_days = s_hours // 24
-    s_hours = s_hours % 24
-
-    # set a minimal run time, if Torque time is < 60 seconds
-    if (s_days == 0) and (s_hours == 0) and (s_minutes == 0):
-        s_minutes = 1
-
-    return "%i-%02i:%02i:00" % (s_days, s_hours, s_minutes)
-
-
-def _add_timing_cmds(commands, file_timing):
-    """Change list of commands, such that system's time is used to trace
-       run-time.
-
-    Parameters
-    ----------
-    commands : [str]
-        List of commands.
-    file_timing : str
-        Filepath to the file into which timing information shall be written
-
-    Returns
-    -------
-    [str] list of changed commands with timing capability.
-    """
-    timing_cmds = []
-    # report machine name
-    timing_cmds.append('uname -a > %s' % file_timing)
-    # report commands to be executed (I have problems with quotes)
-    # timing_cmds.append('echo `%s` >> ${PBS_JOBNAME}.t${PBS_JOBID}'
-    #                    % '; '.join(cmds))
-    # add time to every command
-    for cmd in commands:
-        # cd cannot be timed and any attempt will fail changing the
-        # directory
-        if cmd.startswith('cd ') or\
-           cmd.startswith('module load ') or\
-           cmd.startswith('var_') or\
-           cmd.startswith('export ') or\
-           cmd.startswith('source ') or\
-           cmd.startswith('ulimit '):
-                timing_cmds.append(cmd)
-        elif cmd.startswith('if [ '):
-            ifcon, rest = re.findall(
-                r'(if \[.+?\];\s*then\s*)(.+)', cmd, re.IGNORECASE)[0]
-            timing_cmds.append(('%s '
-                                '%s '
-                                '-v '
-                                '-o %s '
-                                '-a %s') %
-                               (ifcon, settings.EXEC_TIME, file_timing, rest))
-        else:
-            timing_cmds.append(('%s '
-                                '-v '
-                                '-o %s '
-                                '-a %s') %
-                               (settings.EXEC_TIME, file_timing, cmd))
-    return timing_cmds
-
-
-def get_conda_activate_cmd(use_grid, environment):
-    if settings.GRIDNAME == 'JLU':
-        # but remember to to create the ~/.bash_profile file and copy and paste conda init script from .bashrc!
-        if use_grid is False:
-            cmd_conda = "source %s/etc/profile.d/conda.sh; conda activate %s; " % (settings.DIR_CONDA, environment)
-        else:
-            cmd_conda = "conda activate %s; " % (environment)
-    elif settings.GRIDNAME == 'JLU_SLURM':
-        cmd_conda = "source %s/etc/profile.d/conda.sh; conda activate %s; " % (settings.DIR_CONDA, environment)
-    else:
-        cmd_conda = "source %s/etc/profile.d/conda.sh; %s/condabin/conda activate %s; " % (
-            settings.DIR_CONDA, settings.DIR_CONDA, environment)
-    return cmd_conda
-
-def cluster_run(cmds, jobname, result, environment=None,
-                walltime='4:00:00', nodes=1, ppn=10, pmem='8GB',
-                gebin=settings.GRIDENGINE_BINDIR, dry=True, wait=False,
-                file_qid=None, file_condaenvinfo=None, out=sys.stdout,
-                err=sys.stderr, timing=False, file_timing=None, array=1,
-                use_grid=settings.USE_GRID,
-                force_slurm=False, no_mail=False):
-    """ Submits a job to the cluster.
-
-    Paramaters
-    ----------
-    cmds : [str]
-        List of commands to be run on the cluster.
-    jobname : str
-        A name for the cluster job.
-    result : path
-        A file or dir holding results of a sucessful run. Don't re-submit if
-        result exists.
-    environment : str
-        Name of a conda environment to activate.
-    walltime : str
-        Format hh:mm:ss maximal CPU time for the job. Default: '4:00:00'.
-    nodes : int
-        Number of nodes onto the job should be distributed. Defaul: 1
-    ppn : int
-        Number of cores within one node onto which the job should be
-        distributed. Default 10.
-    pmem : str
-        Format 'xGB'. Memory requirement per ppn for the job, e.g. if ppn=10
-        and pmem=8GB the node must have at least 80GB free memory.
-        Default: '8GB'.
-    gebin : path
-        Path to the dir holding SGE binaries.
-        Default: /opt/torque-4.2.8/bin
-    dry : bool
-        Only print command instead of executing it. Good for debugging.
-        Default = True
-    wait : bool
-        Wait for job completion before qsub's return
-    file_qid : str
-        Default None. Create a file containing the qid of the submitted job.
-        This will ease identification of TMP working directories.
-    file_condaenvinfo : str
-        Default: None.
-        If specified, AND environment is not None,
-        the result of "conda list --name X" is written to this file.
-    out : StringIO
-        Buffer onto which messages should be printed. Default is sys.stdout.
-    err : StringIO
-        Default: sys.stderr.
-        Buffer for status reports.
-    timing : bool
-        If True than add time output to every command and store in cr_*.t*
-        file. Default is False.
-    file_timing : str
-        Default: None
-        Define filepath into which timeing information shall be written.
-    array : int
-        Default: 1
-        If > 1 than an array job is submitted. Make sure in- and outputs can
-        deal with ${PBS_ARRAY_INDEX}!
-        Only available for Torque.
-    use_grid : bool
-        Defaul: True.
-        If False, commands are executed locally instead of submitting them to
-        a HPC (= either Torque or Slurm).
-    force_slurm : bool
-        Default: False.
-        If True, cluster_run is enforeced to choose slurm instead of auto
-        detection based on machine node name.
-    no_mail : bool
-        Default: False
-        If True, will not send emails about exit status when complete.
-
-    Returns
-    -------
-    Cluster job ID as str.
-    """
-    VALID_CMDS_KEYS = ['pre', 'main', 'post']
-
-    if result is None:
-        raise ValueError("You need to specify a result path.")
-    parent_res_dir = "/".join(result.split('/')[:-1])
-    if not os.access(parent_res_dir, os.W_OK):
-        raise ValueError("Parent result directory '%s' is not writable!" %
-                         parent_res_dir)
-    if file_qid is not None:
-        if not os.access('/'.join(file_qid.split('/')[:-1]), os.W_OK):
-            raise ValueError("Cannot write qid file '%s'." % file_qid)
-    if os.path.exists(result):
-        if err:
-            err.write("%s already computed\n" % jobname)
-        return "Result already present!"
-    if jobname is None:
-        raise ValueError("You need to set a jobname!")
-    if len(jobname) <= 1:
-        raise ValueError("You need to set non empty jobname!")
-
-    if isinstance(cmds, str):
-        cmds = [cmds]
-    # new mechanism: I want to enable job dependencies, i.e. some commands need
-    # to finish (e.g. prepare command input files) before an array job can
-    # highly parallel be executed e.g. rarefaction iterations.
-    # Therefore, I expect cmds to be a dictionary with keys 'pre' 'main' and
-    # 'post'
-    if isinstance(cmds, dict):
-        if set(cmds.keys() - set(VALID_CMDS_KEYS)) != set([]):
-            raise ValueError(
-                ("your command dictionary has unknown keys: '%s'. "
-                 "Please only use 'pre', 'main', and 'post'!") % "','".join(
-                    set(cmds.keys() - set(VALID_CMDS_KEYS))))
-    elif isinstance(cmds, list):
-        # no specific command category given, assume all commands shall be "main"
-        cmds = {'pre': [], 'main': cmds, 'post': []}
-    assert isinstance(cmds, dict)
-
-    for cmdtype in VALID_CMDS_KEYS:
-        for cmd in cmds[cmdtype]:
-            if "'" in cmd:
-                raise ValueError("One of your commands contain a ' char. "
-                                 "Please remove!")
-
-    fps_timing = {k: None for k in VALID_CMDS_KEYS}
-    if timing:
-        for cmdtype in VALID_CMDS_KEYS:
-            if file_timing is None:
-                fps_timing[cmdtype] = '%s.t${%s}.%s' % (jobname, settings.VARNAME_PBSARRAY, cmdtype)
-            else:
-                fps_timing[cmdtype] = '%s.%s' % (file_timing, cmdtype)
-            if cmdtype != 'main':
-                fps_timing[cmdtype] = fps_timing[cmdtype].replace('${%s}' % settings.VARNAME_PBSARRAY, '')
-            cmds[cmdtype] = _add_timing_cmds(cmds[cmdtype], fps_timing[cmdtype])
-
-    cmd_list = {k: "" for k in VALID_CMDS_KEYS}
-    cmd_conda = ""
-    env_present = None
-    fps_scripts = dict()
-    if environment is not None:
-        if file_condaenvinfo is None:
-            file_condaenvinfo = ""
-        else:
-            file_condaenvinfo = " > %s" % file_condaenvinfo
-        # check if environment exists
-        if '/' not in environment:  # special case where we use environments in non standard paths
-            with subprocess.Popen("%s/condabin/conda list -n %s %s" % (settings.DIR_CONDA, environment, file_condaenvinfo),
-                                  shell=True,
-                                  stdout=subprocess.PIPE) as env_present:
-                if (env_present.wait() != 0):
-                    raise ValueError("Conda environment '%s' not present." %
-                                     environment)
-        cmd_conda = get_conda_activate_cmd(use_grid, environment)
-        # if settings.GRIDNAME == 'JLU':
-        #     # but remember to to create the ~/.bash_profile file and copy and paste conda init script from .bashrc!
-        #     if use_grid is False:
-        #         cmd_conda = "source %s/etc/profile.d/conda.sh; conda activate %s; " % (settings.DIR_CONDA, environment)
-        #     else:
-        #         cmd_conda = "conda activate %s; " % (environment)
-        # elif settings.GRIDNAME == 'JLU_SLURM':
-        #     cmd_conda = "source %s/etc/profile.d/conda.sh; conda activate %s; " % (settings.DIR_CONDA, environment)
-        # else:
-        #     cmd_conda = "source %s/etc/profile.d/conda.sh; %s/condabin/conda activate %s; " % (
-        #         settings.DIR_CONDA, settings.DIR_CONDA, environment)
-
-    slurm = False
-    if use_grid is False:
-        cmd_list['SPAWN'] = cmd_conda
-        cmd_list['SPAWN'] += " && ".join(cmds['pre'])
-        if len(cmds['pre']) > 0:
-            cmd_list['SPAWN'] += ' && '
-        cmd_list['SPAWN'] += ' for %s in `seq 1 %i`; do %s; done;' % (
-            settings.VARNAME_PBSARRAY, array, " && ".join(cmds['main']))
-        cmd_list['SPAWN'] += ' %s' % " && ".join(cmds['post'])
-    else:
-        pwd = subprocess.check_output(["pwd"]).decode('ascii').rstrip()
-
-        if (settings.GRIDNAME == 'USF') or (settings.PREFER_SLURM):
-            slurm = True
-        else:
-            slurm = False
-        with subprocess.Popen("which srun" if slurm else "which qsub",
-                              shell=True, stdout=subprocess.PIPE,
-                              executable="bash") as call_x:
-            if call_x.wait() != 0:
-                msg = ("You don't seem to have access to a grid!")
-                if dry:
-                    if err is not None:
-                        err.write(msg)
-                else:
-                    raise ValueError(msg)
-        if force_slurm:
-            slurm = True
-
-        if slurm is False:
-            highmem = ''
-            if settings.GRIDNAME == 'barnacle':
-                if ppn * int(pmem[:-2]) > 250:
-                    highmem = ':highmem'
-            files_loc = ''
-            if file_qid is not None:
-                files_loc = ' -o %s/ -e %s/ ' % tuple(
-                    ["/".join(file_qid.split('/')[:-1])] * 2)
-
-            flag_array = ''
-            if array > 1:
-                if settings.GRIDNAME == 'barnacle' or settings.GRIDNAME == 'JLU':
-                    flag_array = '-t 1-%i' % array
-                elif settings.GRIDNAME == 'HPCHHU':
-                    flag_array = '-J 1-%i' % array
-            resources = " -l walltime=%s,nodes=%i%s:ppn=%i,mem=%s " % (
-                walltime, nodes, highmem, ppn, pmem)
-            if settings.GRIDNAME == 'JLU':
-                # further differentiate between old and new 18.04 cluster (08.04.2020)
-                arg_multislot = " -pe multislot %i " % ppn
-                #if settings.GRIDENGINE_BINDIR == '/usr/bin/':
-                    # according to Burkhard, the "new cluster" doesn't have multislots yet
-                    # UPDATE: 2021-01-06: "das PE ist da, sollte auch funktionieren"
-                #    arg_multislot = ""
-                pmem_value = pmem
-                if pmem is None:
-                    pmem_value = '8GB'
-                else:
-                    pmem_value = pmem[:-1] if pmem.upper().endswith('B') else pmem
-                resources = " -l virtual_free=%s %s -S /bin/bash " % (pmem_value, arg_multislot)
-            ge_cmd = (
-                ("%s/qsub %s %s -V %s -N cr_%s %s %s -r y") %
-                (gebin,
-                 '-A %s' % settings.GRID_ACCOUNT if settings.GRID_ACCOUNT != "" else "",
-                 "-d '%s'" % pwd if settings.GRIDNAME == 'barnqacle' else '',
-                 resources,
-                 jobname, flag_array, files_loc))
-            cmd_list['main'] += "echo '%s%s' | %s" % (cmd_conda, " && ".join(cmds), ge_cmd)
-        else:
-            for cmdtype in VALID_CMDS_KEYS:
-                slurm_script = "#!/bin/bash\n\n"
-                slurm_script += '#SBATCH --job-name=cr_%s_%s\n' % (jobname, cmdtype)
-                slurm_script += '#SBATCH --output=%s/slurmlog-%%x-%%A.%%a_%s.log\n' % (pwd if file_qid is None else os.path.abspath(os.path.dirname(file_qid)), cmdtype)
-                slurm_script += '#SBATCH --error=%s/slurmlog-%%x-%%A.%%a_%s.err\n' % (pwd if file_qid is None else os.path.abspath(os.path.dirname(file_qid)), cmdtype)
-                slurm_script += '#SBATCH --partition=%s\n' % settings.GRID_ACCOUNT
-                slurm_script += '#SBATCH --ntasks=1\n'
-                slurm_script += '#SBATCH --cpus-per-task=%i\n' % ppn
-                slurm_script += '#SBATCH --mem-per-cpu=%s\n' % (pmem.upper() if pmem is not None else '8GB')
-                slurm_script += '#SBATCH --time=%s\n' % _time_torque2slurm(
-                    walltime)
-                if cmdtype == 'main':
-                    slurm_script += '#SBATCH --array=1-%i\n' % array
-                if cmdtype == 'post' and (no_mail is False):
-                    slurm_script += '#SBATCH --mail-type=END,FAIL\n'
-                    slurm_script += '#SBATCH --mail-user=%s\n\n' % settings.GRID_EMAIL_NOTIFICATION
-                slurm_script += '$(which uname) -a\n'
-
-                for cmd in cmds[cmdtype]:
-                    if cmdtype != 'main':
-                        assert settings.VARNAME_PBSARRAY not in cmd, "array job can only be used in 'main'"
-                    slurm_script += '%s\n' % (cmd.replace(
-                        '${%s}' % settings.VARNAME_PBSARRAY, '${SLURM_ARRAY_TASK_ID}'))
-                if file_qid is not None:
-                    file_script = os.path.dirname(file_qid) + '/slurm_script_%s.sh' % cmdtype
-                else:
-                    _, file_script = mkstemp(suffix='.slurm.sh')
-                fps_scripts[cmdtype] = file_script
-                f = open(fps_scripts[cmdtype], 'w')
-                f.write(slurm_script)
-                f.close()
-            # if on jupyterlab from BCF@JLU, some slurm vars are predefined for the
-            # spawner process of the jupyterlab. We need to unset this specific
-            # variable to avoid slurm complaining about other resource requests.
-            if settings.GRIDNAME == 'JLU_SLURM':
-                cmd_list['SPAWN'] = 'unset SLURM_MEM_PER_NODE && '
-            cmd_list['SPAWN'] += cmd_conda
-            cmd_list['SPAWN'] += ' qid_pre=`%ssbatch --parsable %s`' % (settings.GRIDENGINE_BINDIR, fps_scripts['pre'])
-            cmd_list['SPAWN'] += ' && qid_main=`%ssbatch --parsable --dependency=aftercorr:$qid_pre %s`' % (settings.GRIDENGINE_BINDIR, fps_scripts['main'])
-            cmd_list['SPAWN'] += ' && %ssbatch --parsable --depend=afterany:$qid_main %s' % (settings.GRIDENGINE_BINDIR, fps_scripts['post'])
-
-    if dry is True:
-        if use_grid and slurm:
-            for cmdtype in VALID_CMDS_KEYS:
-                out.write('CONTENT OF %s:\n' % fps_scripts[cmdtype])
-                with open(fps_scripts[cmdtype], 'r') as f:
-                    out.write(''.join(f.readlines()) + "\n\n")
-        out.write(cmd_list['SPAWN'] + "\n")
-        return None
-    else:
-        if use_grid is True:
-            with subprocess.Popen(
-                    cmd_list['SPAWN'], shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, executable='/bin/bash') as task_qsub:
-                err_msg = task_qsub.stderr.read()
-                if err_msg != b"":
-                    raise ValueError("Error in submitting job via qsub:\n%s" % err_msg.decode('ascii'))
-                qid = task_qsub.stdout.read().decode('ascii').rstrip()
-                #if settings.GRIDNAME == 'JLU':
-                #    qid = qid.split(" ")[2]
-                if slurm:
-                    qid = qid.split()[-1]
-                    if file_qid is not None:
-                        os.remove(file_script)
-                if file_qid is not None:
-                    f = open(file_qid, 'w')
-                    f.write('Cluster job ID is:\n%s\n' % qid)
-                    f.close()
-                job_ever_seen = False
-                if wait:
-                    err.write(
-                        "\nWaiting for %s-cluster job %s to complete: " % ('slurm' if slurm else 'sge', qid))
-                    while True:
-                        if slurm:
-                            with subprocess.Popen(
-                                    ['squeue', '--job', qid],
-                                    stdout=subprocess.PIPE) as task_squeue:
-                                with subprocess.Popen(
-                                        ['wc', '-l'], stdin=task_squeue.stdout,
-                                        stdout=subprocess.PIPE) as task_wc:
-                                    poll_status = \
-                                        int(task_wc.stdout.read().decode(
-                                            'ascii').rstrip())
-                            # Two ore more if polling gives a table with header
-                            # and one status line, i.e. job is still on the
-                            # grid. Translate that to 0 of Torque.
-                            # If table has only one line, i.e. the header, job
-                            # terminated (hopefully successful), translate that
-                            # to 1 of Torque
-                            if poll_status >= 2:
-                                poll_status = 0
-                            else:
-                                poll_status = 1
-                        else:
-                            poll_stati = []
-                            for i in range(array):
-                                p = subprocess.call(
-                                    "%s/qstat %s %s" %
-                                    (gebin,
-                                     ' -j ' if settings.GRIDNAME == 'JLU' else '',
-                                     qid.replace('[]', '[%i]' % (i+1))),
-                                    shell=True)
-                                poll_stati.append(p == 0)
-                            if any(poll_stati):
-                                poll_status = 0
-                            else:
-                                poll_status = 127  # some number != 0
-                        if (poll_status != 0) and job_ever_seen:
-                            err.write(' finished.')
-                            break
-                        elif (poll_status == 0) and (not job_ever_seen):
-                            job_ever_seen = True
-                        err.write('.')
-                        time.sleep(10)
-                else:
-                    err.write("Now wait until %s job finishes.\n" % qid)
-                return qid
-        else:
-            #if settings.GRIDNAME == 'JLU':
-            #    cmd_list = 'source ~/.profile && ' + cmd_list
-            with subprocess.Popen(cmd_list['SPAWN'],
-                                  shell=True,
-                                  stdout=subprocess.PIPE,
-                                  stderr=subprocess.PIPE,
-                                  executable="bash") as call_x:
-                if (call_x.wait() != 0):
-                    out, err = call_x.communicate()
-                    raise ValueError((
-                        "SYSTEM CALL FAILED.\n==== STDERR ====\n%s"
-                        "\n\n==== STDOUT ====\n%s\n") % (
-                            err.decode("utf-8", 'backslashreplace'),
-                            out.decode("utf-8", 'backslashreplace')))
-                return call_x.pid
-
-
 def detect_distant_groups_alpha(alpha, groupings,
                                 min_group_size=21,
                                 fct_test=mannwhitneyu):
@@ -2335,103 +1870,6 @@ def mutate_sequence(sequence, num_mutations=1,
             raise ValueError("Alphabet is too small to find mutation!")
         mut_sequence = mut_sequence[:pos] + mut + mut_sequence[pos+1:]
     return mut_sequence
-
-
-def cache(func):
-    """Decorator: Cache results of a function call to disk.
-
-    Parameters
-    ----------
-    func : executabale
-        A function plus parameters whichs results shall be cached, e.g.
-        "fct_example(1,5,3)", where
-        @cache
-        def fct_test(a, b, c):
-            return a + b * c
-    cache_filename : str
-        Default: None. I.e. caching is deactivated.
-        Pathname to cache file, which will hold results of the function call.
-        If file exists, results are loaded from it instead of recomputing via
-        provided function. Otherwise, function will be executed and results
-        stored to this file.
-    cache_verbose : bool
-        Default: True.
-        Report caching status to 'cache_err', which by default is sys.stderr.
-    cache_err : StringIO
-        Default: sys.stderr.
-        Stream onto which status messages shall be printed.
-    cache_force_renew : bool
-        Default: False.
-        Force re-execution of provided function even if cache file exists.
-
-    Returns
-    -------
-    Results of provided function, either by actually executing the function
-    with provided parameters or by loaded results from filename.
-
-    Notes
-    -----
-    It is the obligation of the user to ensure that arguments for the provided
-    function don't change between creation of cache file and loading from cache
-    file!
-    """
-    func_name = func.__name__
-
-    def execute(*args, **kwargs):
-        cache_args = {'cache_filename': None,
-                      'cache_verbose': True,
-                      'cache_err': sys.stderr,
-                      'cache_force_renew': False}
-        for varname in cache_args.keys():
-            if varname in kwargs:
-                cache_args[varname] = kwargs[varname]
-                del kwargs[varname]
-
-        if cache_args['cache_filename'] is None:
-            if cache_args['cache_verbose']:
-                cache_args['cache_err'].write(
-                    '%s: no caching, since "cache_filename" is None.\n' %
-                    func_name)
-            return func(*args, **kwargs)
-
-        if os.path.exists(cache_args['cache_filename']) and\
-           (os.stat(cache_args['cache_filename']).st_size <= 0):
-            if cache_args['cache_verbose']:
-                cache_args['cache_err'].write(
-                    '%s: removed empty cache.\n' %
-                    func_name)
-            os.remove(cache_args['cache_filename'])
-
-        if (not os.path.exists(cache_args['cache_filename'])) or\
-           cache_args['cache_force_renew']:
-            try:
-                f = open(cache_args['cache_filename'], 'wb')
-                results = func(*args, **kwargs)
-                pickle.dump(results, f)
-                f.close()
-                if cache_args['cache_verbose']:
-                    cache_args['cache_err'].write(
-                        '%s: stored results in cache "%s".\n' %
-                        (func_name, cache_args['cache_filename']))
-            except Exception as e:
-                raise e
-        else:
-            f = open(cache_args['cache_filename'], 'rb')
-            results = pickle.load(f)
-            f.close()
-            if cache_args['cache_verbose']:
-                cache_args['cache_err'].write(
-                    '%s: retrieved results from cache "%s".\n' %
-                    (func_name, cache_args['cache_filename']))
-        return results
-    if func.__doc__ is not None:
-        execute.__doc__ = func.__doc__
-    else:
-        execute.__doc__ = ""
-    execute.__doc__ += "\n\n" + cache.__doc__
-    # restore wrapped function name
-    execute.__name__ = func_name
-    return execute
 
 
 def _map_metadata_calout(metadata, calour_experiment, field):
@@ -4741,7 +4179,16 @@ def parse_bcl_demuxsheet(fp_demux:str, return_all_data:bool=False):
 
     return samples
 
-def plot_alpha_trajectory(alpha_diversity:pd.DataFrame, metadata:pd.DataFrame, time:str, time_order:[str], hue_field:str, hue_order:[str], hue_palette=None, width_factor=0.3, stratification=None, stratification_order:[str]=[], min_num_samples:int=21):
+
+def _adjust_color(color, lightness_factor=1.3, saturation_factor=0.9):
+    # Wandelt "red", "#ff0000", (1,0,0) etc. einheitlich in RGB um
+    rgb = mcolors.to_rgb(color)
+    h, l, s = colorsys.rgb_to_hls(*rgb)
+    l = min(1, l * lightness_factor)
+    s = s * saturation_factor
+    return colorsys.hls_to_rgb(h, l, s)
+
+def plot_alpha_trajectory(alpha_diversity:pd.DataFrame, metadata:pd.DataFrame, time:str, time_order:[str], hue_field:str, hue_order:[str], hue_palette=None, width_factor=0.3, stratification=None, stratification_order:[str]=[], min_num_samples:int=21, verbose=sys.stderr, fp_figure=None, title="", isbeta=False):
     """For data with multiple time points: box-plots for alpha diversity along temporal axis, stratefied into small number of groups.
 
     Parameters
@@ -4770,6 +4217,14 @@ def plot_alpha_trajectory(alpha_diversity:pd.DataFrame, metadata:pd.DataFrame, t
     min_number_samples : int
         Default: 21.
         Minimal number of samples to perform a Mann-Whitney-Test
+    verbose : StringIO
+        Default is sys.stderr
+    fp_figure : str
+        Default is None.
+        If set to a valid filepath (directory will be created), the figure is
+        stored as an SVG.
+    title : str
+        Append title to figure suptitle.
     """
     (a, metadata) = sync_counts_metadata(alpha_diversity.T, metadata)
     alpha_diversity = a.T
@@ -4792,7 +4247,7 @@ def plot_alpha_trajectory(alpha_diversity:pd.DataFrame, metadata:pd.DataFrame, t
                 raise ValueError("You provided %i strate in via 'stratification_order=[...]', but the following do not exist in your data!\n  " % (len(non_existant_strata), '\n  '.join(non_existant_strata)))
             # follow given order and append non specified strata
         stratification_order = stratification_order + list(set(samplesites) - set(stratification_order))
-        fig, axes = plt.subplots(len(samplesites), alpha_diversity.shape[1],
+        fig, axes = plt.subplots(alpha_diversity.shape[1], len(samplesites),
                                  figsize=(width_factor * len(time_order) * len(hue_order) * len(samplesites), alpha_diversity.shape[1] * 5),
                                  gridspec_kw={'hspace': 0.25}, squeeze=False)
     else:
@@ -4806,25 +4261,32 @@ def plot_alpha_trajectory(alpha_diversity:pd.DataFrame, metadata:pd.DataFrame, t
     #time, time_order = 'smj_role_time', ['control', 'a', 'b', 'c', 'd', 'e']
     num_sign = 0
     num_p_sign = 0
+    # metadata might already contain alpha div columns!
+    data = metadata[[c for c in metadata.columns if c not in alpha_diversity.columns]].merge(alpha_diversity, left_index=True, right_index=True)
+    strip_palette = hue_palette
+    if hue_palette is not None:
+        strip_palette = {k: _adjust_color(v) for k,v in hue_palette.items()}
     for row, (axrow, metric) in enumerate(zip(axes, alpha_diversity.columns)):
         for col, (ax, samplesite) in enumerate(zip(axrow, stratification_order)):
             num_sig_tests = 0
             if samplesites != ['']:
-                plotdata = metadata[(metadata[stratification] == samplesite)]
+                plotdata = data[(data[stratification] == samplesite)]
             else:
-                plotdata = metadata
+                plotdata = data
+            # states might be given in user order BUT data for this category might be missing
             pres_order = [tp for tp in time_order if tp in plotdata[time].unique()]
-            sns.boxplot(plotdata, y=metric, x=time, ax=ax, order=pres_order, legend=True, hue=hue_field, showfliers=False, hue_order=hue_order, palette=hue_palette)
+            pres_hue_order = [h for h in hue_order if h in plotdata[hue_field].unique()]
+            sns.boxplot(plotdata, y=metric, x=time, ax=ax, order=pres_order, legend=True, hue=hue_field, showfliers=False, hue_order=pres_hue_order, palette=hue_palette)
             xpos = []
             for patch in ax.patches:
                 if isinstance(patch, matplotlib.patches.PathPatch):
                     bbox = patch.get_path().get_extents()
                     xpos.append((bbox.x1 - bbox.x0) / 2 + bbox.x0)
             xpos = sorted(xpos)
-            sns.stripplot(plotdata, y=metric, x=time, ax=ax, order=pres_order, hue=hue_field, dodge=True, palette='gray', legend=False, hue_order=hue_order)
+            sns.stripplot(plotdata, y=metric, x=time, ax=ax, order=pres_order, hue=hue_field, dodge=True, palette=strip_palette, legend=False, hue_order=pres_hue_order)
 
             if col == 0:
-                ax.set_ylabel("α-diversity\n%s" % NICE_METRICS[metric])
+                ax.set_ylabel("α-diversity\n%s" % settings.NICE_METRICS.get(metric, metric))
             else:
                 ax.set_ylabel("")
             if row == 0:
@@ -4840,12 +4302,12 @@ def plot_alpha_trajectory(alpha_diversity:pd.DataFrame, metadata:pd.DataFrame, t
             threshold = min_num_samples
             tests = [((tp, catA), (tp, catB))
                      for tp in pres_order
-                     for (catA, catB) in combinations(hue_order, 2)
+                     for (catA, catB) in combinations(pres_hue_order, 2)
                      if ns_hue.get((tp, catA), 0) >= threshold
                      if ns_hue.get((tp, catB), 0) >= threshold]
             if True and (len(tests) > 0):
-                annotator = Annotator(ax, tests, data=plotdata, y=metric, x=time, order=pres_order, hue=hue_field, hue_order=hue_order)
-                annotator.configure(test='Mann-Whitney', text_format='star', loc='inside', comparisons_correction="fdr_bh", correction_format="default", verbose=0)
+                annotator = Annotator(ax, tests, data=plotdata, y=metric, x=time, order=pres_order, hue=hue_field, hue_order=pres_hue_order)
+                annotator.configure(test='Mann-Whitney', text_format='star', loc='inside', comparisons_correction="fdr_bh", correction_format="default", verbose=0 if verbose is None else 1)
                 _ = annotator.apply_and_annotate()
                 num_sig_tests = sum([1 if t.__dict__['data'].__dict__['_corrected_significance'] == True else 0 for t in annotator.__dict__['annotations']] )
                 num_p_sign += sum([1 if t.__dict__['data'].__dict__['pvalue'] == True else 0 for t in annotator.__dict__['annotations']] )
@@ -4853,32 +4315,42 @@ def plot_alpha_trajectory(alpha_diversity:pd.DataFrame, metadata:pd.DataFrame, t
 
             offset = 0.2
             axTop = ax.twiny()
-            #xpos = [ x + ((hue - (len(hue_order) - (1 if len(hue_order) % 2 == 0 else 0)) / 2) * (1 - offset) / len(hue_order))
-            #         for x in range(len(pres_order))
-            #         for hue in range(len(hue_order))]
             xlabels = [ ns_hue[(x, hue)]
                         for x in pres_order
-                        for hue in hue_order if (x, hue) in ns_hue.keys() ]
+                        for hue in pres_hue_order if (x, hue) in ns_hue.keys() ]
             axTop.set_xticks(xpos, xlabels)
             axTop.set_xlim(ax.get_xlim())
             axTop.grid(False)
             if ((len(samplesites) > 1) and (row == 0) and (col == 2)) or ((len(samplesites) == 1) and (row == 0) and (col == 0)):
-                ax.legend(bbox_to_anchor=(1.1, 1.05))
+                ax.legend(bbox_to_anchor=(1.1, 1.05), title=hue_field)
             else:
                 ax.legend().remove()
 
     if num_sign <= 0:
         print("Alpha: No significant differences found!")
 
-    fig.suptitle('(p < 0.05: %i, q < 0.05: %i)' % (num_p_sign, num_sign))
+    fig.suptitle('%s%s(p < 0.05: %i, q < 0.05: %i)' % (title, " " if title != "" else "", num_p_sign, num_sign))
+
+    if fp_figure is not None:
+        os.makedirs(fp_figure, exist_ok=True)
+        fp_fig = os.path.join(fp_figure, 'trajectory_alpha_%s%s%s-%s.svg' % (title.replace(' ', ''), "" if title == "" else '-', time, hue_field))
+
+        if isbeta:
+            for ax in fig.get_axes():
+                ax.set_ylabel('%s β distance\nto healthy sibling(s)' % ax.get_ylabel().split('\n')[-1])
+            fp_fig = fp_fig.replace('_alpha_', '_beta_')
+
+        fig.savefig(fp_fig, bbox_inches='tight')
 
     return fig
 
 
+from ggmap.correlations import adonis
 def plot_beta_trajectory(beta_diversity:dict[str, DistanceMatrix], metadata:pd.DataFrame,
                          time:str, time_order:[str], hue_field:str, hue_paired_order:[(str, str)]=[], hue_palette=None, stratification=None,
                          enforce_same:[str]=[], min_num_samples:int=5,
-                         num_permutations:int=999, fp_figures=None, precomputed_results=None, add_stripplot:bool=False, show_num_data:bool=False):
+                         num_permutations:int=999, fp_figures=None, precomputed_results=None, add_stripplot:bool=False, show_num_data:bool=False,
+                         verbose=sys.stderr):
     """For data with multiple time points: box-plots for beta diversity pairwise comparisons along temporal axis; one row of panels per stratefied group.
 
     Parameters
@@ -4903,7 +4375,7 @@ def plot_beta_trajectory(beta_diversity:dict[str, DistanceMatrix], metadata:pd.D
         in an figure.
     enforce_same : [str]
         Only consider pairwise distances where both samples have the same
-        values for these metadata columns
+        values for these metadata columns. Also implies use of anova.
     min_number_samples : int
         Default: 5.
         Minimal number of samples to perform a PERMANOVA-Test
@@ -4923,6 +4395,8 @@ def plot_beta_trajectory(beta_diversity:dict[str, DistanceMatrix], metadata:pd.D
         Default is False.
         Mainly for debugging. In addition to n=sample numbers also print d=x,
         where x is number of pairwise distances.
+    verbose : StringIO
+        Default is sys.stderr
     """
     sign_type = 'q-value'
     beta_diversity, metadata = sync_distances_metadata(beta_diversity, metadata)
@@ -5005,15 +4479,27 @@ def plot_beta_trajectory(beta_diversity:dict[str, DistanceMatrix], metadata:pd.D
                                 results['infos'][ikey] = {'n': ns.get(_a, 0)}
                         ikey = tuple([metric, samplesite, agebin, a, b, 'inter', None, '@'.join(map(str, [hue_paired_order.index(cmp), 1]))])
                         if ns.loc[[a, b]].min() >= min_num_samples:
-                            res_perm = permanova(DistanceMatrix(data=dm.loc[sidx, sidx], ids=sidx), g.loc[sidx, hue_field], permutations=num_permutations)
+                            if len(enforce_same) > 0:
+                                metaAdonis = g.loc[sidx, :].copy()
+                                metaAdonis['ADONISSTRATUM'] = metaAdonis[enforce_same].apply(lambda x: 'AND'.join(x.values), axis=1)
+                                res_adonis = adonis(metaAdonis, beta_diversity[metric].filter(sidx), formula=hue_field, strat='ADONISSTRATUM', dry=False, use_grid=True, wait=False, verbose=verbose)
+                                res_test = {'test_name': 'adonis (%s ~ %s)' % (hue_field, ','.join(enforce_same))}
+                                if res_adonis['results'] is not None:
+                                    res_test['p-value'] = res_adonis['results']['table'].loc['Model', 'Pr(>F)']
+                                else:
+                                    res_test['p-value'] = 1.0
+                                    verbose.write("adonis2 results not yet ready. Please call me again later.\n")
+                            else:
+                                res_test = permanova(DistanceMatrix(data=dm.loc[sidx, sidx], ids=sidx), g.loc[sidx, hue_field], permutations=num_permutations)
+                                res_test['test_name'] = "permanova"
                         else:
-                            res_perm = {'p-value': np.nan}
-                        results['infos'][ikey] = {'p-value': res_perm['p-value']}
+                            res_test = {'p-value': np.nan, 'test_name': 'too few samples'}
+                        results['infos'][ikey] = {'p-value': res_test['p-value'], 'test_name': res_test['test_name']}
                         if results['infos'][ikey]['p-value'] < 0.05:
-                            print("  ", '%.3f' % res_perm['p-value'], metric, samplesite, agebin, ns.loc[a], ns.loc[b], a, ' <-> ', b, dm.loc[sidx, sidx].shape)
+                            print("  ", '%.3f' % res_test['p-value'], metric, samplesite, agebin, ns.loc[a], ns.loc[b], a, ' <-> ', b, dm.loc[sidx, sidx].shape, res_test['test_name'])
         results['dists'] = pd.concat(results['dists'])
         results['infos'] = pd.DataFrame(results['infos']).T.reset_index()
-        results['infos'].columns = ['metric', stratification, time, hue_field + '_a', hue_field + '_b', 'type', 'sub_' + hue_field, 'joined_hue', 'n_samples', 'p-value']
+        results['infos'].columns = ['metric', stratification, time, hue_field + '_a', hue_field + '_b', 'type', 'sub_' + hue_field, 'joined_hue', 'n_samples', 'p-value', 'stat.test']
     else:
         results = precomputed_results
         results['infos'] = results['infos'].reset_index()
@@ -5024,7 +4510,7 @@ def plot_beta_trajectory(beta_diversity:dict[str, DistanceMatrix], metadata:pd.D
     results['infos']['color'] = results['infos'].apply(lambda row: hue_palette['inter'] if row['type'] == 'inter' else hue_palette[row['sub_' + hue_field]], axis=1)
     grouping_columns = ['metric'] + ([stratification] if stratification is not None else [])
     for _, g in results['infos'].groupby(grouping_columns):
-        ps = g['p-value'].dropna()
+        ps = g['p-value'].dropna().astype(float)
         results['infos'].loc[ps.index, 'q-value'] = false_discovery_control(ps.values, method='bh')
     results['infos'] = results['infos'].set_index(grouping_columns).sort_index()
 
@@ -5047,15 +4533,7 @@ def plot_beta_trajectory(beta_diversity:dict[str, DistanceMatrix], metadata:pd.D
 
     num_sign_results = 0
 
-    def _adjust_color(color, lightness_factor=1.3, saturation_factor=0.9):
-        # Wandelt "red", "#ff0000", (1,0,0) etc. einheitlich in RGB um
-        rgb = mcolors.to_rgb(color)
-        h, l, s = colorsys.rgb_to_hls(*rgb)
-        l = min(1, l * lightness_factor)
-        s = s * saturation_factor
-        return colorsys.hls_to_rgb(h, l, s)
     strip_palette = {k: _adjust_color(v) for k,v in palette.items()}
-
     for group, g in tqdm(results['dists'].groupby(grouping_columns), "3/3 stat. testing and plotting"):
         num_signs = dict()
         for t in ['p-value', 'q-value']:
@@ -5075,6 +4553,7 @@ def plot_beta_trajectory(beta_diversity:dict[str, DistanceMatrix], metadata:pd.D
                 sns.boxplot(data=plotdata, orient='h', x='distance', ax=ax, hue='joined_hue', hue_order=joined_hue_order, palette=palette, legend=False, showfliers=not add_stripplot)
                 if add_stripplot:
                     sns.stripplot(data=plotdata, orient='h', x='distance', ax=ax, hue='joined_hue', hue_order=joined_hue_order, palette=strip_palette, dodge=True, legend=False)
+
                 axRight = ax.twinx()
                 axRight.set_ylim(ax.get_ylim())
 
@@ -5098,11 +4577,36 @@ def plot_beta_trajectory(beta_diversity:dict[str, DistanceMatrix], metadata:pd.D
                     if ndists is not None:
                         if label != "":
                             label += "\n"
-                        label += 'd=%i' % ndists.get(row.name, 99999999)
+                        label += 'd=%i' % ndists.get(row.name, 0)
                     return label
                 rl = sub_infos.apply(lambda row: _generate_n_labels(row, ndists=ndists if show_num_data else None), axis=1).to_dict()
                 right_labels = [rl.get(x, '') for x in joined_hue_order if not x.startswith('spacer_')]
                 axRight.set_yticks(positions, right_labels)
+                axRight.grid(False)
+
+                if len(enforce_same) > 0:
+                    # subset to boxes with at least 21 distances
+                    pw_tests = [(cmp, joined_hue) for (cmp, joined_hue), n in plotdata.groupby(['cmp', 'joined_hue']).size().items() if n > 20]
+                    # ensure at least two (intra, intra) or (intra, inter) boxes have sufficient number of distances
+                    pw_tests = [list(g['joined_hue'].values) for cmp, g in pd.DataFrame(pw_tests, columns=['cmp', 'joined_hue']).groupby('cmp') if g.shape[0] >= 2]
+                    # create all pairs within hue for boxes with sufficient number of samples
+                    pw_tests = [((group[0], a), (group[0], b)) for hue in pw_tests for (a,b) in combinations(hue, 2) ]
+                    #pw_tests = [(a, b) for hue in pw_tests for (a,b) in combinations(hue, 2) ]
+
+                    if len(pw_tests) > 0:
+                        # brackets of statannotations will have an offset, if dummy
+                        # spacer hue values are missing. Thus, we need to add fake values
+                        # here to the actual data to be plotted.
+                        dummydata = []
+                        for h in joined_hue_order:
+                            if h.startswith('spacer_'):
+                                dummydata.append({'distance': 0, 'metric': group[0], 'joined_hue': h})
+                        dummydata = pd.DataFrame(dummydata)
+
+                        annotator = Annotator(ax=ax, pairs=pw_tests, data=pd.concat([plotdata, dummydata]), x='distance', y='metric', hue='joined_hue', hue_order=joined_hue_order, orient='h')
+                        annotator.configure(test='Mann-Whitney', text_format='star', loc='inside', comparisons_correction="fdr_bh", correction_format="default", verbose=0 if verbose is None else 1)
+                        _ = annotator.apply_and_annotate()
+
 
         ls = results['infos'].fillna({'sub_' + hue_field: 'vs.'}).groupby(['joined_hue', 'sub_' + hue_field]).size().reset_index().set_index('joined_hue')['sub_' + hue_field].to_dict()
         labels = [ls.get(c, 0) for c in joined_hue_order if not c.startswith('spacer_')]
@@ -5120,7 +4624,6 @@ def plot_beta_trajectory(beta_diversity:dict[str, DistanceMatrix], metadata:pd.D
             fp_fig = os.path.join(fp_figures, 'trajectory_beta_%s%s-%s-%s.svg' % (group[1]+'-' if stratification is not None else '', group[0], time, hue_field))
             fig.savefig(fp_fig, bbox_inches='tight')
         plt.show()
-        break
 
     if num_sign_results <= 0:
         print("Beta: No significant differences found!")
@@ -5128,7 +4631,6 @@ def plot_beta_trajectory(beta_diversity:dict[str, DistanceMatrix], metadata:pd.D
     return results
 
 
-from ggmap.analyses import ancom
 def plot_ancom_trajectory(counts, taxonomy, precomputed_results, metadata:pd.DataFrame, time:str, hue_field:str, stratification=None, use_grid:bool=True, fp_figures=None, hue_palette=None, verbose=sys.stderr):
     """For data with multiple time points: run ANCOM-BC for pairwise comparisons along temporal axis for ranks Phylum to Genus.
 
@@ -5161,6 +4663,7 @@ def plot_ancom_trajectory(counts, taxonomy, precomputed_results, metadata:pd.Dat
         Default: True.
         Use grid to compute ANCOM.
     """
+    from ggmap.analyses import ancom
 
     num_sign = 0
     grouping_columns = [time, hue_field + '_a', hue_field + '_b']
@@ -5171,6 +4674,7 @@ def plot_ancom_trajectory(counts, taxonomy, precomputed_results, metadata:pd.Dat
         grouping_columns.insert(0, stratification)
     metric_derep_infos = precomputed_results['infos'].sort_values(by='q-value', ascending=True).groupby(grouping_columns).head(1)
 
+    results = dict()
     for group, row in metric_derep_infos[metric_derep_infos['q-value'] < 0.05].iterrows():
         cmp_dists = precomputed_results['dists'][(precomputed_results['dists']['reference_' + hue_field] == row[hue_field + '_a']) &
                                                  (precomputed_results['dists']['other_' + hue_field] == row[hue_field + '_b']) &
@@ -5178,8 +4682,13 @@ def plot_ancom_trajectory(counts, taxonomy, precomputed_results, metadata:pd.Dat
         if stratification is not None:
              cmp_dists = cmp_dists[cmp_dists[stratification] == group[1]]
         cmp_samples = list(cmp_dists[['reference_sample_name', 'other_sample_name']].stack().unique())
-
+        cmp_samples = [s for s in cmp_samples if s in metadata.index]
         for rank in settings.RANKS[1:-2]:
+            _key = list(map(lambda x: x, row.loc[[time, hue_field + '_a', hue_field + '_b']].values)) + [rank]
+            if stratification is not None:
+                _key += [group[1]]
+            _key = tuple(_key)
+
             res_ancom = ancom(counts.loc[:, cmp_samples], rank, taxonomy, metadata.loc[cmp_samples, hue_field], dry=False, wait=False, use_grid=use_grid,
                               post_cache_arguments={'title': '%s%s=%s' % (group[1] + ', ' if stratification is not None else '', time, row[time]), 'palette': hue_palette}, verbose=verbose)
             if res_ancom['results'] is not None:
@@ -5209,6 +4718,9 @@ def plot_ancom_trajectory(counts, taxonomy, precomputed_results, metadata:pd.Dat
                         #else:
                         res_ancom['results']['figure'].savefig(fp_fig, bbox_inches='tight')
 
+
+                    results[_key] = res_ancom['results']
+
     if num_sign <= 0:
         print("Ancom: no significant findings.")
-    return num_sign
+    return (num_sign, results)

--- a/ggmap/snippets.py
+++ b/ggmap/snippets.py
@@ -1,46 +1,53 @@
+import os
+from io import StringIO
 import decimal
 from typing import Dict
-import pandas as pd
-import biom
-from biom.util import biom_open
-from itertools import repeat, chain, cycle
-import numpy as np
-import matplotlib as mpl
-import matplotlib.patches as mpatches
-from matplotlib.font_manager import FontProperties
-import os
-import seaborn as sns
-import matplotlib.pyplot as plt
 import subprocess
 import sys
 import time
-from itertools import combinations
-from skbio.stats.distance import permanova, DistanceMatrix
-from scipy.stats import mannwhitneyu, kruskal
-import networkx as nx
+from itertools import repeat, chain, cycle, combinations
 import warnings
-import matplotlib.cbook
 import random
 from tempfile import mkstemp
 import pickle
-from ggmap import settings
 import re
 from sklearn.model_selection import train_test_split
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.utils.multiclass import unique_labels
 from sklearn.metrics import confusion_matrix
-from matplotlib.lines import Line2D
-from matplotlib.patches import Patch
 import math
-from skbio.sequence import DNA
-from skbio.tree import TreeNode
 from wordcloud import WordCloud
 import requests
 from tqdm import tqdm
 import calour as ca
 ca.set_log_level(40)
 from statannotations.Annotator import Annotator
-from io import StringIO
+import colorsys
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+from matplotlib.patches import Patch
+from matplotlib.lines import Line2D
+import matplotlib.cbook
+from matplotlib.font_manager import FontProperties
+import matplotlib.colors as mcolors
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+import seaborn as sns
+from scipy.stats import mannwhitneyu, kruskal, false_discovery_control
+
+import biom
+from biom.util import biom_open
+
+from skbio.stats.distance import permanova, DistanceMatrix
+from skbio.sequence import DNA
+from skbio.tree import TreeNode
+
+from ggmap import settings
+
 
 if 'PROJ_LIB' not in os.environ:
     os.environ['PROJ_LIB'] = os.path.join(*([os.path.sep] + sys.executable.split(os.path.sep)[:-2] + ['share', 'proj']))
@@ -49,6 +56,14 @@ from mpl_toolkits.basemap import Basemap
 settings.init()
 plt.rcParams['svg.fonttype'] = 'none'
 
+NICE_METRICS = {
+    'shannon': 'Shannon',
+    'observed_features': 'number observed ASVs',
+    'PD_whole_tree': 'Faith\'s PD',
+
+    'bray_curtis': 'Bray-Curtis',
+    'unweighted_unifrac': 'unweighted UniFrac',
+    'weighted_unifrac': 'weighted UniFrac'}
 
 def biom2pandas(file_biom, withTaxonomy=False, astype=int):
     """ Converts a biom file into a Pandas.DataFrame
@@ -3944,6 +3959,45 @@ def sync_counts_metadata(featuretable: pd.DataFrame, metadata: pd.DataFrame, ver
     return (sub_featuretable, sub_metadata)
 
 
+def sync_distances_metadata(beta_diversity: dict[str: DistanceMatrix], metadata: pd.DataFrame, verbose=sys.stderr):
+    """Subsets samples that appear in distance matrix and metdata.
+
+    Parameters
+    ----------
+    beta_diversity : dict[str: DistanceMatrix]
+        A dictionary of square, non-negative distance matrix. Key is metric name, values are skbio DistanceMatrix
+    metadata : pd.DataFrame
+        metadata information for samples.
+
+    Returns
+    -------
+    (beta_diversity: dict of DistanceMatrix, metadata: pd.DataFrame)
+    """
+    metrics = list(sorted(beta_diversity.keys()))
+
+    # limit to samples that are present in ALL distance matrices
+    sids_in_all_dms = set(beta_diversity[metrics[0]].ids)
+    for metric in metrics[1:]:
+        sids_in_all_dms &= set(beta_diversity[metric].ids)
+    if len(sids_in_all_dms) <= 0:
+        raise ValueError("Your distance matrices containe non-overlapping samples!")
+
+    # further limit set of samples to those that are also present in metadata
+    sids_in_all_dms &= set(metadata.index)
+    if len(sids_in_all_dms) <= 0:
+        raise ValueError("No samples common in DistanceMatrices and metadata!")
+
+    sub_distances = {metric: beta_diversity[metric].filter([s for s in beta_diversity[metric].ids if s in metadata.index if s in sids_in_all_dms])
+                     for metric in beta_diversity.keys()}
+    sub_metadata = metadata.loc[[s for s in metadata.index if s in sids_in_all_dms]]
+
+    if (sub_distances[metrics[0]].shape[0] < beta_diversity[metrics[0]].shape[0]) or (sub_metadata.shape[0] < metadata.shape[0]):
+        if verbose is not None:
+            verbose.write('Reduced to %i samples (DistanceMatrices had %i, metadata had %i samples)\n' % (sub_metadata.shape[0], beta_diversity[metrics[0]].shape[0], metadata.shape[0]))
+
+    return (sub_distances, sub_metadata)
+
+
 def check_column_presents(metadata: pd.DataFrame, column_names: [str]):
     missing_columns = []
     for colname in column_names:
@@ -4137,8 +4191,6 @@ def plot_circles(meta: pd.DataFrame, cols_grps: Dict[str, str]=None, colors: Dic
 
 def adjust_saturation(color, amount=0.5):
     # copied from https://stackoverflow.com/questions/37765197/darken-or-lighten-a-color-in-matplotlib
-    import matplotlib.colors as mc
-    import colorsys
     try:
         c = mc.cnames[color]
     except:
@@ -4688,3 +4740,475 @@ def parse_bcl_demuxsheet(fp_demux:str, return_all_data:bool=False):
         raise ValueError("%i samples have barcodes that contain ' ', maybe at their end:\n%s" % (len(idx_barcode_issue), issues))
 
     return samples
+
+def plot_alpha_trajectory(alpha_diversity:pd.DataFrame, metadata:pd.DataFrame, time:str, time_order:[str], hue_field:str, hue_order:[str], hue_palette=None, width_factor=0.3, stratification=None, stratification_order:[str]=[], min_num_samples:int=21):
+    """For data with multiple time points: box-plots for alpha diversity along temporal axis, stratefied into small number of groups.
+
+    Parameters
+    ----------
+    alpha_diversity : pd.DataFrame
+        Dataframe with multiple alpha diversity metrics as columns and samples as rows.
+    metadata : pd.DataFrame
+        Dataframe with information about samples.
+    time : str
+        Column in metadata table that discriminates time points.
+    time_order : [str]
+        An ordered list of all timepoint values in metadata[time]
+    hue_field : str
+        Column in metadata table that discriminates groups of samples at each time point.
+    hue_order : [str]
+        An ordered list of all group values in metadata[hue_field]
+    hue_palette : dict[str, str]
+        A dictionary as a palette for hue values.
+    stratification : str
+        Default: None
+        Column in metadata table to stratify samples. Each group will result
+        in an extra column of panels.
+    stratification_order : [str]
+        Default: []
+        Order in which strata shall be plotted as columns of panels.
+    min_number_samples : int
+        Default: 21.
+        Minimal number of samples to perform a Mann-Whitney-Test
+    """
+    (a, metadata) = sync_counts_metadata(alpha_diversity.T, metadata)
+    alpha_diversity = a.T
+
+    check_column_presents(metadata, [time, hue_field] + ([] if stratification is None else [stratification]))
+
+    missing_time = set(metadata[time].unique()) - set(time_order)
+    if len(missing_time) > 0:
+        raise ValueError("Missing values '%s' in time_order!" % "','".join(map(str, missing_time)))
+    missing_hue = set(metadata[hue_field].unique()) - set(hue_order)
+    if len(missing_hue) > 0:
+        raise ValueError("Missing values '%s' in hue_order!" % "','".join(map(str, missing_hue)))
+
+    fig, axes = None, None
+    if stratification is not None:
+        samplesites = sorted(metadata[stratification].dropna().unique())
+        if len(stratification_order) == 0:
+            non_existant_strata = set(stratification_order) - set(samplesites)
+            if len(non_existant_strata) > 0:
+                raise ValueError("You provided %i strate in via 'stratification_order=[...]', but the following do not exist in your data!\n  " % (len(non_existant_strata), '\n  '.join(non_existant_strata)))
+            # follow given order and append non specified strata
+        stratification_order = stratification_order + list(set(samplesites) - set(stratification_order))
+        fig, axes = plt.subplots(len(samplesites), alpha_diversity.shape[1],
+                                 figsize=(width_factor * len(time_order) * len(hue_order) * len(samplesites), alpha_diversity.shape[1] * 5),
+                                 gridspec_kw={'hspace': 0.25}, squeeze=False)
+    else:
+        samplesites, stratification_order = [''], ['']
+        fig, axes = plt.subplots(alpha_diversity.shape[1], 1,
+                                 figsize=(width_factor * len(time_order) * len(hue_order), alpha_diversity.shape[1] * 5),
+                                 gridspec_kw={'hspace': 0.25}, squeeze=False)
+    #hue_order = ['never', 'up to 6 months', 'more than 6 months']
+    #hue_field = 'smj_breastfeed_bin'
+    #time, time_order = 'smj_age_class', ['Newborn', 'Infant', 'Toddler', 'Early childhood', 'Middle childhood', 'Early adolescence', 'Adult']
+    #time, time_order = 'smj_role_time', ['control', 'a', 'b', 'c', 'd', 'e']
+    num_sign = 0
+    num_p_sign = 0
+    for row, (axrow, metric) in enumerate(zip(axes, alpha_diversity.columns)):
+        for col, (ax, samplesite) in enumerate(zip(axrow, stratification_order)):
+            num_sig_tests = 0
+            if samplesites != ['']:
+                plotdata = metadata[(metadata[stratification] == samplesite)]
+            else:
+                plotdata = metadata
+            pres_order = [tp for tp in time_order if tp in plotdata[time].unique()]
+            sns.boxplot(plotdata, y=metric, x=time, ax=ax, order=pres_order, legend=True, hue=hue_field, showfliers=False, hue_order=hue_order, palette=hue_palette)
+            xpos = []
+            for patch in ax.patches:
+                if isinstance(patch, matplotlib.patches.PathPatch):
+                    bbox = patch.get_path().get_extents()
+                    xpos.append((bbox.x1 - bbox.x0) / 2 + bbox.x0)
+            xpos = sorted(xpos)
+            sns.stripplot(plotdata, y=metric, x=time, ax=ax, order=pres_order, hue=hue_field, dodge=True, palette='gray', legend=False, hue_order=hue_order)
+
+            if col == 0:
+                ax.set_ylabel("α-diversity\n%s" % NICE_METRICS[metric])
+            else:
+                ax.set_ylabel("")
+            if row == 0:
+                ax.set_title(samplesite)
+            ns = plotdata.groupby(time, observed=False).size()#.to_dict()
+            ns.index = ns.index.astype('str')
+            ns = ns.to_dict()
+
+            ax.set_xticks(ax.get_xticks(), ['n=%i\n%s' % (ns.get((t.get_text()), 0), t.get_text()) for t in ax.get_xticklabels()])
+            ax.set_xlabel("")
+
+            ns_hue = plotdata.groupby([time, hue_field], observed=False).size().to_dict()
+            threshold = min_num_samples
+            tests = [((tp, catA), (tp, catB))
+                     for tp in pres_order
+                     for (catA, catB) in combinations(hue_order, 2)
+                     if ns_hue.get((tp, catA), 0) >= threshold
+                     if ns_hue.get((tp, catB), 0) >= threshold]
+            if True and (len(tests) > 0):
+                annotator = Annotator(ax, tests, data=plotdata, y=metric, x=time, order=pres_order, hue=hue_field, hue_order=hue_order)
+                annotator.configure(test='Mann-Whitney', text_format='star', loc='inside', comparisons_correction="fdr_bh", correction_format="default", verbose=0)
+                _ = annotator.apply_and_annotate()
+                num_sig_tests = sum([1 if t.__dict__['data'].__dict__['_corrected_significance'] == True else 0 for t in annotator.__dict__['annotations']] )
+                num_p_sign += sum([1 if t.__dict__['data'].__dict__['pvalue'] == True else 0 for t in annotator.__dict__['annotations']] )
+            num_sign += num_sig_tests
+
+            offset = 0.2
+            axTop = ax.twiny()
+            #xpos = [ x + ((hue - (len(hue_order) - (1 if len(hue_order) % 2 == 0 else 0)) / 2) * (1 - offset) / len(hue_order))
+            #         for x in range(len(pres_order))
+            #         for hue in range(len(hue_order))]
+            xlabels = [ ns_hue[(x, hue)]
+                        for x in pres_order
+                        for hue in hue_order if (x, hue) in ns_hue.keys() ]
+            axTop.set_xticks(xpos, xlabels)
+            axTop.set_xlim(ax.get_xlim())
+            axTop.grid(False)
+            if ((len(samplesites) > 1) and (row == 0) and (col == 2)) or ((len(samplesites) == 1) and (row == 0) and (col == 0)):
+                ax.legend(bbox_to_anchor=(1.1, 1.05))
+            else:
+                ax.legend().remove()
+
+    if num_sign <= 0:
+        print("Alpha: No significant differences found!")
+
+    fig.suptitle('(p < 0.05: %i, q < 0.05: %i)' % (num_p_sign, num_sign))
+
+    return fig
+
+
+def plot_beta_trajectory(beta_diversity:dict[str, DistanceMatrix], metadata:pd.DataFrame,
+                         time:str, time_order:[str], hue_field:str, hue_paired_order:[(str, str)]=[], hue_palette=None, stratification=None,
+                         enforce_same:[str]=[], min_num_samples:int=5,
+                         num_permutations:int=999, fp_figures=None, precomputed_results=None, add_stripplot:bool=False, show_num_data:bool=False):
+    """For data with multiple time points: box-plots for beta diversity pairwise comparisons along temporal axis; one row of panels per stratefied group.
+
+    Parameters
+    ----------
+    beta_diversity : dict[str, pd.DataFrame]
+        A dictionary of multiple skbio.DistanceMatrix objects. Key is name of metric.
+    metadata : pd.DataFrame
+        Dataframe with information about samples.
+    time : str
+        Column in metadata table that discriminates time points.
+    time_order : [str]
+        An ordered list of all timepoint values in metadata[time]
+    hue_field : str
+        Column in metadata table that discriminates groups of samples at each time point.
+    hue_paired_order : [(str, str)]
+        An ordered list of pairs of group values for comparisons, must name all possible pairs of group values in metadata[hue_field]
+    hue_palette : dict[str, str]
+        A dictionary as a palette for hue values.
+    stratification : str
+        Default: None
+        Column in metadata table to stratify samples. Each group will result
+        in an figure.
+    enforce_same : [str]
+        Only consider pairwise distances where both samples have the same
+        values for these metadata columns
+    min_number_samples : int
+        Default: 5.
+        Minimal number of samples to perform a PERMANOVA-Test
+    num_permutations : int
+        Number of permutations in PERMANOVA. Default is 999.
+    fp_figures : str
+        Default is None.
+        If set to a valid filepath (directory will be created), each figure is
+        stored as an SVG.
+    precomputed_results : dict()
+        Pass the return value of a previous run of this function to save re-computing distances and
+        statistical tests.
+    add_stripplot : bool
+        Default is False. Enable more insights into data by overlying boxplots with
+        stripplots of the same data.
+    show_num_data : bool
+        Default is False.
+        Mainly for debugging. In addition to n=sample numbers also print d=x,
+        where x is number of pairwise distances.
+    """
+    sign_type = 'q-value'
+    beta_diversity, metadata = sync_distances_metadata(beta_diversity, metadata)
+
+    check_column_presents(metadata, [time, hue_field] + ([] if stratification is None else [stratification]) + enforce_same)
+    missing_time = set(metadata[time].unique()) - set(time_order)
+    if len(missing_time) > 0:
+        raise ValueError("Missing values '%s' in time_order!" % "','".join(map(str, missing_time)))
+
+    def _order_hue_pairs(metadata, hue_field, hue_paired_order):
+        expected_hue_pairs = list(combinations(metadata[hue_field].dropna().unique(), 2))
+        final_order = []
+        covered_pairs = []
+        unexpected_pairs = []
+        for (a, b) in hue_paired_order:
+            if (a, b) in expected_hue_pairs:
+                covered_pairs.append((a, b))
+            elif (b, a) in expected_hue_pairs:
+                covered_pairs.append((b, a))
+            else:
+                unexpected_pairs.append((a, b))
+        if len(unexpected_pairs) > 0:
+            raise ValueError("You defined the following %i pairs in hue_paired_order=... but at least one of their partners does not exist in your metadata[%s] column!\n  " % (
+                len(unexpected_pairs), hue_field, '\n  '.join(map(lambda x: '(%s, %s)' % (x[0], x[1]), unexpected_pairs))))
+        final_order = hue_paired_order + [p for p in expected_hue_pairs if p not in covered_pairs]
+        # ensure a < b for each pair
+        final_order = [(a, b) if a <= b else (b, a) for (a, b) in final_order]
+        return final_order
+    hue_paired_order = _order_hue_pairs(metadata, hue_field, hue_paired_order)
+
+    results = {'dists': [], 'infos': dict(), 'figures': dict()}
+    infos = dict()
+    dists = []
+    if stratification is not None:
+        samplesites = sorted(metadata[stratification].dropna().unique())
+    else:
+        samplesites = ['']
+    #figures = dict()
+    if precomputed_results is None:
+        for row, metric in tqdm(enumerate(beta_diversity.keys()), "1/3 Collecting distances"):
+            dm = beta_diversity[metric].to_data_frame()
+            dm.index.name = 'reference_sample_name'
+            dm.columns.name = 'other_sample_name'
+
+            for col, samplesite in enumerate(samplesites):
+                if samplesites != ['']:
+                    plotdata = metadata[(metadata[stratification] == samplesite)]
+                else:
+                    plotdata = metadata
+                plotdata = plotdata.loc[[s for s in dm.index if s in plotdata.index], :]
+                for agebin, g in plotdata.groupby(time):
+                    ns = g[hue_field].value_counts()
+                    for (a, b) in combinations(ns.index, 2):
+                        (a, b) = tuple(sorted([a, b]))
+                        sidx = g[g[hue_field].isin([a, b])].index
+                        cmp = (a, b)
+                        for (_a, _b) in [(a, a), (b, b), (a, b)]:
+                            d = None
+                            if _a == _b:
+                                d = get_triu_dists(dm.loc[list(g[g[hue_field] == _a].index), list(g[g[hue_field] == _b].index)]).reset_index()
+                            else:
+                                d = dm.loc[list(g[g[hue_field] == _a].index), list(g[g[hue_field] == _b].index)].stack().rename('distance').reset_index()
+                            for forced_col in enforce_same:
+                                filter = metadata.loc[d['reference_sample_name'].values, forced_col].values == metadata.loc[d['other_sample_name'].values, forced_col].values
+                                d = d[filter]
+                            d['metric'] = metric
+                            d[stratification] = samplesite
+                            d[time] = agebin
+                            d['reference_' + hue_field] = _a
+                            d['other_' + hue_field] = _b
+                            d['cmp'] = ' vs. '.join(cmp)
+                            _type = 'inter' if (_a != _b) else 'intra %s' % _a
+                            d['type'] = _type
+                            joined_hue = [hue_paired_order.index(cmp), 1 if (_a != _b) else (0 if _a == cmp[0] else 2)]
+                            d['joined_hue'] = '@'.join(map(str, joined_hue))
+                            results['dists'].append(d)
+
+                            ikey = tuple([metric, samplesite, agebin, a, b, _type.split()[0], _a, '@'.join(map(str, joined_hue))])
+                            if _type != 'inter':
+                                results['infos'][ikey] = {'n': ns.get(_a, 0)}
+                        ikey = tuple([metric, samplesite, agebin, a, b, 'inter', None, '@'.join(map(str, [hue_paired_order.index(cmp), 1]))])
+                        if ns.loc[[a, b]].min() >= min_num_samples:
+                            res_perm = permanova(DistanceMatrix(data=dm.loc[sidx, sidx], ids=sidx), g.loc[sidx, hue_field], permutations=num_permutations)
+                        else:
+                            res_perm = {'p-value': np.nan}
+                        results['infos'][ikey] = {'p-value': res_perm['p-value']}
+                        if results['infos'][ikey]['p-value'] < 0.05:
+                            print("  ", '%.3f' % res_perm['p-value'], metric, samplesite, agebin, ns.loc[a], ns.loc[b], a, ' <-> ', b, dm.loc[sidx, sidx].shape)
+        results['dists'] = pd.concat(results['dists'])
+        results['infos'] = pd.DataFrame(results['infos']).T.reset_index()
+        results['infos'].columns = ['metric', stratification, time, hue_field + '_a', hue_field + '_b', 'type', 'sub_' + hue_field, 'joined_hue', 'n_samples', 'p-value']
+    else:
+        results = precomputed_results
+        results['infos'] = results['infos'].reset_index()
+
+    print("2/3 Collecting meta information", file=sys.stderr)
+    if 'inter' not in hue_palette.keys():
+        hue_palette['inter'] = 'gray'
+    results['infos']['color'] = results['infos'].apply(lambda row: hue_palette['inter'] if row['type'] == 'inter' else hue_palette[row['sub_' + hue_field]], axis=1)
+    grouping_columns = ['metric'] + ([stratification] if stratification is not None else [])
+    for _, g in results['infos'].groupby(grouping_columns):
+        ps = g['p-value'].dropna()
+        results['infos'].loc[ps.index, 'q-value'] = false_discovery_control(ps.values, method='bh')
+    results['infos'] = results['infos'].set_index(grouping_columns).sort_index()
+
+    joined_hue_order = []
+    for s in sorted(results['dists']['joined_hue'].unique()):
+        if len(joined_hue_order) > 0 and joined_hue_order[-1].split('@')[0] != s.split('@')[0]:
+            joined_hue_order.append("spacer_%i" % len(joined_hue_order))
+        joined_hue_order.append(s)
+
+    palette = results['infos'].loc[results['infos'].index[0]].groupby(['joined_hue', 'color']).size().reset_index().set_index('joined_hue')['color'].to_dict()
+    for h in joined_hue_order:
+        if h.startswith('spacer_'):
+            palette[h] = 'black'
+        elif h not in palette.keys():
+            palette[h] = 'gray'
+
+    width = 0.8  # seaborn default
+    box_width = width / len(joined_hue_order)
+    positions = [-width/2 + box_width * (i + 0.5) for i in range(len(joined_hue_order)) if not joined_hue_order[i].startswith('spacer_')]
+
+    num_sign_results = 0
+
+    def _adjust_color(color, lightness_factor=1.3, saturation_factor=0.9):
+        # Wandelt "red", "#ff0000", (1,0,0) etc. einheitlich in RGB um
+        rgb = mcolors.to_rgb(color)
+        h, l, s = colorsys.rgb_to_hls(*rgb)
+        l = min(1, l * lightness_factor)
+        s = s * saturation_factor
+        return colorsys.hls_to_rgb(h, l, s)
+    strip_palette = {k: _adjust_color(v) for k,v in palette.items()}
+
+    for group, g in tqdm(results['dists'].groupby(grouping_columns), "3/3 stat. testing and plotting"):
+        num_signs = dict()
+        for t in ['p-value', 'q-value']:
+            num_signs[t] = (results['infos'].loc[group][t].dropna() < 0.05).value_counts().to_dict().get(True, 0)
+        if num_signs[sign_type] <= 0:
+            continue
+        num_sign_results += 1
+
+        fig, axes = plt.subplots(1, len(time_order), figsize=(len(time_order) * 4, 5/3*len(hue_paired_order)), sharey=True, gridspec_kw={'wspace': 0.35})
+
+        for (ax, ageclass) in zip(axes, time_order):
+            ax.set_title(ageclass)
+            ax.set_xlabel(NICE_METRICS.get(group[0], group[0]))
+            plotdata = g[g[time] == ageclass].copy()
+            ndists = plotdata.groupby(['joined_hue']).size().to_dict()
+            if plotdata.shape[0] > 0:
+                sns.boxplot(data=plotdata, orient='h', x='distance', ax=ax, hue='joined_hue', hue_order=joined_hue_order, palette=palette, legend=False, showfliers=not add_stripplot)
+                if add_stripplot:
+                    sns.stripplot(data=plotdata, orient='h', x='distance', ax=ax, hue='joined_hue', hue_order=joined_hue_order, palette=strip_palette, dodge=True, legend=False)
+                axRight = ax.twinx()
+                axRight.set_ylim(ax.get_ylim())
+
+                # labels for right y-axes: n-samples if "intra" else p-value
+                sub_infos = results['infos'].reset_index()
+                sub_infos = sub_infos[(sub_infos['metric'] == group[0]) &
+                                      (sub_infos[time] == ageclass)]
+                if stratification is not None:
+                    sub_infos = sub_infos[sub_infos[stratification] == group[1]]
+                sub_infos = sub_infos.set_index('joined_hue')
+
+                def _generate_n_labels(row, ndists=None, significance_niveau=0.05):
+                    label = ""
+                    if row['type'] == 'intra':
+                        label += 'n=%i' % row['n_samples']
+                    else:
+                        if pd.notnull(row[sign_type]):
+                            label += '%.3f' % row[sign_type]
+                            if row[sign_type] < significance_niveau:
+                                label += ' *'
+                    if ndists is not None:
+                        if label != "":
+                            label += "\n"
+                        label += 'd=%i' % ndists.get(row.name, 99999999)
+                    return label
+                rl = sub_infos.apply(lambda row: _generate_n_labels(row, ndists=ndists if show_num_data else None), axis=1).to_dict()
+                right_labels = [rl.get(x, '') for x in joined_hue_order if not x.startswith('spacer_')]
+                axRight.set_yticks(positions, right_labels)
+
+        ls = results['infos'].fillna({'sub_' + hue_field: 'vs.'}).groupby(['joined_hue', 'sub_' + hue_field]).size().reset_index().set_index('joined_hue')['sub_' + hue_field].to_dict()
+        labels = [ls.get(c, 0) for c in joined_hue_order if not c.startswith('spacer_')]
+        axes[0].set_yticks(positions, labels)
+
+        # adding one legend at the rightmost time plot
+        legend_elements = [Patch(color=color, label=val) for val, color in results['infos'].fillna({'sub_' + hue_field: 'inter'}).groupby('sub_' + hue_field)['color'].unique().apply(lambda x: x[0]).items()]
+        axes[-1].legend(handles=legend_elements, bbox_to_anchor=(2, 1))
+
+        fig.suptitle('%s(p < 0.05: %i, q < 0.05: %i)' % (group[1] + ', ' if stratification is not None else '', num_signs['p-value'], num_signs['q-value']))
+        results['figures'][group] = fig
+        #figures[(samplesite, metric)] = fig
+        if fp_figures is not None:
+            os.makedirs(fp_figures, exist_ok=True)
+            fp_fig = os.path.join(fp_figures, 'trajectory_beta_%s%s-%s-%s.svg' % (group[1]+'-' if stratification is not None else '', group[0], time, hue_field))
+            fig.savefig(fp_fig, bbox_inches='tight')
+        plt.show()
+        break
+
+    if num_sign_results <= 0:
+        print("Beta: No significant differences found!")
+
+    return results
+
+
+from ggmap.analyses import ancom
+def plot_ancom_trajectory(counts, taxonomy, precomputed_results, metadata:pd.DataFrame, time:str, hue_field:str, stratification=None, use_grid:bool=True, fp_figures=None, hue_palette=None, verbose=sys.stderr):
+    """For data with multiple time points: run ANCOM-BC for pairwise comparisons along temporal axis for ranks Phylum to Genus.
+
+    Parameters
+    ----------
+    counts : pd.DataFrame
+        Feature table.
+    taxonomy : pd.Series
+        The taxonomy along which feature counts shall be collapsed.
+    precomputed_results : return value of plot_beta_trajectory
+        Only compute for pairs that reached significance with plot_beta_trajectory.
+        Thus, provide the return value of this function here!
+    metadata : pd.DataFrame
+        Dataframe with information about samples.
+    time : str
+        Column in metadata table that discriminates time points.
+    hue_field : str
+        Column in metadata table that discriminates groups of samples at each time point.
+    hue_palette : dict[str, str]
+        A dictionary as a palette for hue values.
+    stratification : str
+        Default: None
+        Column in metadata table to stratify samples. Each group will result
+        in an figure.
+    fp_figures : str
+        Default is None.
+        If set to a valid filepath (directory will be created), each figure is
+        stored as an SVG.
+    use_grid : Boolean
+        Default: True.
+        Use grid to compute ANCOM.
+    """
+
+    num_sign = 0
+    grouping_columns = [time, hue_field + '_a', hue_field + '_b']
+    stratification = None
+    if len(precomputed_results['infos'].index.names) > 1:
+        stratification = precomputed_results['infos'].index.names[1]
+    if stratification is not None:
+        grouping_columns.insert(0, stratification)
+    metric_derep_infos = precomputed_results['infos'].sort_values(by='q-value', ascending=True).groupby(grouping_columns).head(1)
+
+    for group, row in metric_derep_infos[metric_derep_infos['q-value'] < 0.05].iterrows():
+        cmp_dists = precomputed_results['dists'][(precomputed_results['dists']['reference_' + hue_field] == row[hue_field + '_a']) &
+                                                 (precomputed_results['dists']['other_' + hue_field] == row[hue_field + '_b']) &
+                                                 (precomputed_results['dists'][time] == row[time])]
+        if stratification is not None:
+             cmp_dists = cmp_dists[cmp_dists[stratification] == group[1]]
+        cmp_samples = list(cmp_dists[['reference_sample_name', 'other_sample_name']].stack().unique())
+
+        for rank in settings.RANKS[1:-2]:
+            res_ancom = ancom(counts.loc[:, cmp_samples], rank, taxonomy, metadata.loc[cmp_samples, hue_field], dry=False, wait=False, use_grid=use_grid,
+                              post_cache_arguments={'title': '%s%s=%s' % (group[1] + ', ' if stratification is not None else '', time, row[time]), 'palette': hue_palette}, verbose=verbose)
+            if res_ancom['results'] is not None:
+                anres = res_ancom['results']['summary']
+                #anres['metric'] = row['metric']
+                if stratification is not None:
+                    anres[stratification] = group[1]
+                anres[time] = row[time]
+                anres['n_samples'] = str(metadata.loc[cmp_samples, :].groupby(hue_field).size().values)
+                anres['comparison'] = ' vs. '.join(sorted(metadata.loc[cmp_samples, hue_field].unique()))
+                anres['field'] = hue_field
+                if anres[(anres["significantly different"] == True) & (anres[[c for c in anres.columns if 'mean rel. abundance' in c][0]] == True)].shape[0] > 0:
+                    num_sign += 1
+                    display(anres)
+                    if fp_figures is not None:
+                        os.makedirs(fp_figures, exist_ok=True)
+                        fp_fig = os.path.join(fp_figures, 'trajectory_ancom_%s%s-%s-%s_%s.svg' % (
+                            group[1] + '-' if stratification is not None else '',
+                            #row['metric'],
+                            time,
+                            hue_field,
+                            '-vs-'.join(sorted(map(str, metadata.loc[cmp_samples, hue_field].unique()))),
+                            rank))
+                        #if 'figure' not in res_ancom['results'].keys():
+                        #    print("Figure missing for %s" % ', '.join([row[PREFIXCOL + 'sample_site'], time, hue_field, '-vs-'.join(sorted(map(str, meta.loc[cmp_samples, hue_field].unique()))), rank]))
+                        #    return res_ancom
+                        #else:
+                        res_ancom['results']['figure'].savefig(fp_fig, bbox_inches='tight')
+
+    if num_sign <= 0:
+        print("Ancom: no significant findings.")
+    return num_sign

--- a/ggmap/workflow.py
+++ b/ggmap/workflow.py
@@ -211,14 +211,15 @@ def project_trimprimers(primerseq_fwd:str, primerseq_rev:str, prj_data, verbose=
 def project_deblur(prj_data, trimlength=150, ppn=10, pattern_fwdfiles="*_R1_001.fastq.gz", pmem='8GB', walltime='4:00:00', outdir=None):
     """Expects to find fastq files in prj_data['paths']['trimmed']
        Writes results into prj_data['paths']['deblur'] and prj_data['paths']['deblur_table']"""
-    prj_data['paths']['deblur'] = os.path.join(prj_data['paths']['tmp_workdir'], 'deblur' if outdir is None else outdir)
-
     res_deblur = deblur(prj_data['paths']['trimmed'], trimlength, pattern_fwdfiles, ppn=ppn, dry=False, wait=False, walltime=walltime, pmem=pmem)
     if res_deblur['results'] is not None:
+        prj_data['paths']['deblur'] = os.path.join(prj_data['paths']['tmp_workdir'], 'deblur' if outdir is None else outdir)
         # create temp dir
         os.makedirs('%s/deblur_res' % prj_data['paths']['deblur'], exist_ok=True)
         prj_data['paths']['deblur_table'] = os.path.join(prj_data['paths']['deblur'], 'deblur_res', 'reference-hit.biom')
         pandas2biom(prj_data['paths']['deblur_table'], res_deblur['results']['reference-hit.biom'])
+    else:
+        raise ValueError("Be patient and wait/poll for deblur results!")
 
     return prj_data
 
@@ -230,12 +231,12 @@ def project_sepp(prj_data, ppn=8, verbose=sys.stderr, use_grid=True, debug=False
     res_sepp = sepp(biom2pandas(prj_data['paths']['deblur_table']), ppn=ppn, dry=False, environment=settings.QIIME2_ENV, use_grid=use_grid, debug=debug)
     print('SEPP version number: %s' % ', '.join([line.split()[1] for line in res_sepp['conda_list'] if line.startswith('sepp') or line.startswith('q2-fragment-insertion')]))
     fp_tree = os.path.join(prj_data['paths']['tmp_workdir'], 'sepp_uncorrected_tree.tmp')
-    if not os.path.exists(fp_tree):
+    prj_data['paths']['insertion_tree'] = os.path.join(prj_data['paths']['tmp_workdir'], 'insertion_tree.nwk')
+    if (not os.path.exists(fp_tree)) or (not os.path.exists(prj_data['paths']['insertion_tree'])):
         with open(fp_tree, 'w') as f:
             f.write(res_sepp['results']['tree'])
 
     # correct zero branch length
-    prj_data['paths']['insertion_tree'] = os.path.join(prj_data['paths']['tmp_workdir'], 'insertion_tree.nwk')
     if not os.path.exists(prj_data['paths']['insertion_tree']):
         writeReferenceTree(fp_tree, prj_data['paths']['tmp_workdir'], fix_zero_len_branches=True)
         os.rename(os.path.join(prj_data['paths']['tmp_workdir'], 'reference.tree'), prj_data['paths']['insertion_tree'])
@@ -420,6 +421,9 @@ def process_study(metadata: pd.DataFrame,
     else:
         # default to all features of the counts table, if no insertion tree has been provided
         features_inserted = set(counts.index)
+    num_overlap_features_table_tree = len(set(counts.index) & set(features_inserted))
+    if num_overlap_features_table_tree <= 0:
+        raise ValueError("There are no ASVs of your feature-table inserted in the SEPP tree!!")
 
     # remove features assigned taxonomy to chloroplasts / mitochondria,
     # report min, max removal
@@ -427,7 +431,6 @@ def process_study(metadata: pd.DataFrame,
     results = dict()
     results['counts_plantsStillIn'] = counts
     counts = counts.loc[sorted([feature for feature in counts.index if feature not in idx_chloroplast_mitochondria and feature in features_inserted]), sorted(counts.columns)]
-
     results['taxonomy'] = {'RDP': res_taxonomy, 'GG138': res_taxonomy_GG138}
     results['counts_plantsremoved'] = counts
 

--- a/ggmap/workflow.py
+++ b/ggmap/workflow.py
@@ -1,3 +1,9 @@
+# This file shall contain code for a rapid processing (demux, trimming, deblur, fragment-insertion)
+# and default analysis (alpha, beta, emperor, ) of 16S data.
+# All data shall be stored in a dictionary called "prj_data", which is updated through
+# the below functions. Main output, is the result of function process_study which
+# is my best practise recommendation for normalization, filtering, ... of a 16S data set
+
 from os.path import exists
 import sys
 import requests
@@ -384,21 +390,25 @@ def process_study(metadata: pd.DataFrame,
     # See here:
     # https://forum.qiime2.org/t/taxonomy-filtering-greengenes2/28334
     # GG2 does include chloroplast and mitochondria, but the labels were accidentally not part of the taxonomy decoration, which I'm very well aware of but while this is incredibly important, it is not the highest priority I have at the moment
-    res_taxonomy_GG138 = taxonomy_RDP(counts, fp_taxonomy_trained_classifier_gg138_chloroMitoRemoval, dry=dry, wait=True, use_grid=use_grid, ppn=ppn, environment=conda_env_gg138_chloroMitoRemoval)
-    idx_chloroplast_mitochondria = res_taxonomy_GG138['results'][res_taxonomy_GG138['results']['Taxon'].apply(lambda lineage: 'c__Chloroplast' in lineage or 'f__mitochondria' in lineage)]['Taxon'].index
+    idx_chloroplast_mitochondria = set([])
+    res_taxonomy_GG138 = None
+    if fp_taxonomy_trained_classifier_gg138_chloroMitoRemoval is not None:
+        res_taxonomy_GG138 = taxonomy_RDP(counts, fp_taxonomy_trained_classifier_gg138_chloroMitoRemoval, dry=dry, wait=True, use_grid=use_grid, ppn=ppn, environment=conda_env_gg138_chloroMitoRemoval)
+        idx_chloroplast_mitochondria = res_taxonomy_GG138['results'][res_taxonomy_GG138['results']['Taxon'].apply(lambda lineage: 'c__Chloroplast' in lineage or 'f__mitochondria' in lineage)]['Taxon'].index
 
     # compute taxonomic lineages for feature sequences
-    if fp_taxonomy_trained_classifier != fp_taxonomy_trained_classifier_gg138_chloroMitoRemoval:
+    res_taxonomy = None
+    if (fp_taxonomy_trained_classifier is not None) and (fp_taxonomy_trained_classifier != fp_taxonomy_trained_classifier_gg138_chloroMitoRemoval):
         res_taxonomy = taxonomy_RDP(counts, fp_taxonomy_trained_classifier, dry=dry, wait=True, use_grid=use_grid, ppn=ppn)
     else:
         res_taxonomy = res_taxonomy_GG138
-    idx_chloroplast_mitochondria = res_taxonomy_GG138['results'][res_taxonomy_GG138['results']['Taxon'].apply(lambda lineage: 'c__Chloroplast' in lineage or 'f__mitochondria' in lineage)]['Taxon'].index
 
     if type(control_samples) != set:
         raise ValueError('control samples need to be provided as a SET, not as %s.' % type(control_samples))
-    plant_ratio = counts.loc[[feature for feature in counts.index if feature not in idx_chloroplast_mitochondria], [sample for sample in counts.columns if sample not in control_samples]].sum(axis=0) / counts.loc[:, [sample for sample in counts.columns if sample not in control_samples]].sum(axis=0)
-    if plant_ratio.min() < 0.95:
-        verbose.write('Information: You are loosing a significant amount of reads due to filtration of plant material!\n%s\n' % (1-plant_ratio).sort_values(ascending=False).iloc[:10])
+    if len(idx_chloroplast_mitochondria) > 0:
+        plant_ratio = counts.loc[[feature for feature in counts.index if feature not in idx_chloroplast_mitochondria], [sample for sample in counts.columns if sample not in control_samples]].sum(axis=0) / counts.loc[:, [sample for sample in counts.columns if sample not in control_samples]].sum(axis=0)
+        if plant_ratio.min() < 0.95:
+            verbose.write('Information: You are loosing a significant amount of reads due to filtration of plant material!\n%s\n' % (1-plant_ratio).sort_values(ascending=False).iloc[:10])
 
     if (tree_insert is None) and (fp_insertiontree is not None):
         if tree_insert.count() <= 1:


### PR DESCRIPTION
This PR is a larger and partially braking braking change!
- functions in analyses.py use the _executor function which in turn uses a caching mechanism to avoid re-computation. The cache hash computation for pandas Series / DataFrames was flawed for many years as I simply used the `str()` function to then compute a hash of this representation. For larger DataFrames, ellipsis were returned by `str()`, such that only the first and last 10 rows / cols were actually included in the  string. Changes in the larger rest of data did not effect the hash, i.e. collisions were potentially very HIGH / likely. I've changes that, which means for you, that ggmap most likely will not find existing cached results in your analysis working directory and you need to re-compute (or rename the cached files accordingly). No results were wrong at any time!
- `execute.py`: I decided to re-structure my spaghetti code a bit, i.e. move all functionality necessary to run external programs to the new file "execute.py"
- `analyses.py`:
  - I've harmonized the way how `verbose` is handled as an argument.
  - older versions of `sepp` (which I think nobody used for long time) are now moved to `deprecated.py`
  - `blastn_local` can now handle LARGE result hitlists by applying filters "early", i.e. while parsing individual chunks
- `correlations.py`: annoyed by manually constructing / testing "formulas" for the linear model for forward step redundancy analyses for effect size computation and the fact that I had to call alpha- and beta- versions manually, I put everything in one function `redundancy` and implemented an "auto" mode which first iterates ALL metadata columns (except those defined in `omit`) and computes individual effects and than heuristically composes a model that explains most of variability. **Note**: a smart manual "design" might still out compete this automatic mechanism and you might want to iteratively add columns to `omit` if you know about confounders!
- `snippets.py`: I've added three more functions to visualize alpha- / beta- and ancom results of testing for differences for a metadata column `hue` (e.g. healthy/diseased) across multiple timepoints `time` (e.g. days after intervention) in an optionally "stratified" (e.g. body site) fashion.